### PR TITLE
fix: yomo build init setup

### DIFF
--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -76,17 +76,6 @@ func NewCmdInit() *cobra.Command {
 				return
 			}
 
-			// fix version issue
-			modCmd = exec.Command("go", "mod", "edit", "-replace", "github.com/yomorun/yomo=../../yomorun/yomo")
-			err = modCmd.Run()
-			if err == nil {
-				log.Print("🛠 go.mod replaced")
-			} else {
-				log.Print("🛠 go.mod replace err: ", err.Error())
-				return
-			}
-			modCmd.Run()
-
 			log.Print("✅ Congratulations! You have initialized the serverless app successfully.")
 			log.Print("🎉 You can enjoy the YoMo Serverless via the command: yomo dev")
 		},


### PR DESCRIPTION
currently, the `yomo init` generate a wrong `go.mod`,
which leads to the following error when `yomo dev`

```
$ yomo dev
2021/01/17 16:37:53 Building the Serverless Function File...
2021/01/17 16:37:53 ❌ Build the serverless file failure with err: exit status 1
```

---

- latest yomo 0.7.1 binary
- `yomo init -name test`
- cd test
- `yomo dev`

relates to https://github.com/Homebrew/homebrew-core/pull/67240

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yomorun/yomo/105)
<!-- Reviewable:end -->
