### PR TITLE
fix(example): repair the wrong data output by flow

### DIFF
--- a/example/flow/app.go
+++ b/example/flow/app.go
@@ -23,7 +23,8 @@ type NoiseData struct {
 var printer = func(_ context.Context, i interface{}) (interface{}, error) {
 	value := i.(NoiseData)
 	rightNow := time.Now().UnixNano() / int64(time.Millisecond)
-	return fmt.Sprintf("[%s] %d > value: %f ⚡️=%dms", value.From, value.Time, value.Noise, rightNow-value.Time), nil
+	fmt.Printf("[%s] %d > value: %f ⚡️=%dms\n", value.From, value.Time, value.Noise, rightNow-value.Time)
+	return i, nil
 }
 
 var callback = func(v []byte) (interface{}, error) {


### PR DESCRIPTION
It causes sink to get the wrong data