### PR TITLE
feat(cli): send data back to source

### DIFF
--- a/internal/cmd/wf/run.go
+++ b/internal/cmd/wf/run.go
@@ -87,7 +87,7 @@ func (s *quicHandler) Read(st quic.Stream) error {
 			}
 
 			if s.sendToSource {
-				st.Write(value)
+				go st.Write(value)
 			}
 
 			for _, sink := range sinks {


### PR DESCRIPTION
Add a flag to indicate whether to send the data back to `YoMo-Source`.