### PR TITLE
refactory example task build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 # Dependency directories (remove the comment below to include it)
 .DS_Store
 vendor/
+bin/
 /bin/yomo
 main
 # example

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -4,23 +4,13 @@ version: "3"
 
 output: "prefixed"
 
-# includes:
-#   example:
-#     dir: ./example
-#     taskfile: ./example/Taskfile.yml
-
-# tasks:
-#   default:
-#     dir: ./example
-#     cmds:
-#       - echo "Go to ./example for detail usage, like [task basic:run]"
-#       - echo "🍭 all examples list here"
-#       - ls ./
-#       - echo "🍭 all tasks list here"
-#       - task -l
-#     silent: true
-
-includes:
-  basic:
-    taskfile: ./example/basic/Taskfile.yml
-    dir: ./example/basic
+tasks:
+  default:
+    dir: ./example
+    cmds:
+      - echo "Go to ./example for detail usage, like [task basic:run]"
+      - echo "🍭 all examples list here"
+      - ls ./
+      - echo "🍭 all tasks list here"
+      - task -l
+    silent: true

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -2,15 +2,20 @@
 
 version: "3"
 
-output: 'prefixed'
+output: "prefixed"
 
-includes:
-  example: 
-    dir: ./example
-    taskfile: ./example/Taskfile.yml
+# includes:
+#   example:
+#     dir: ./example
+#     taskfile: ./example/Taskfile.yml
 
 tasks:
   default:
+    dir: ./example
     cmds:
+      - echo "Go to ./example for detail usage, like [task basic:run]"
+      - echo "🍭 all examples list here"
+      - ls ./
+      - echo "🍭 all tasks list here"
       - task -l
     silent: true

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -9,13 +9,18 @@ output: "prefixed"
 #     dir: ./example
 #     taskfile: ./example/Taskfile.yml
 
-tasks:
-  default:
-    dir: ./example
-    cmds:
-      - echo "Go to ./example for detail usage, like [task basic:run]"
-      - echo "🍭 all examples list here"
-      - ls ./
-      - echo "🍭 all tasks list here"
-      - task -l
-    silent: true
+# tasks:
+#   default:
+#     dir: ./example
+#     cmds:
+#       - echo "Go to ./example for detail usage, like [task basic:run]"
+#       - echo "🍭 all examples list here"
+#       - ls ./
+#       - echo "🍭 all tasks list here"
+#       - task -l
+#     silent: true
+
+includes:
+  basic:
+    taskfile: ./example/basic/Taskfile.yml
+    dir: ./example/basic

--- a/example/Taskfile.yml
+++ b/example/Taskfile.yml
@@ -1,8 +1,13 @@
 # https://taskfile.dev
 
-version: '3'
+version: "3"
 
-output: 'prefixed'
+output: "prefixed"
+
+includes:
+  basic:
+    taskfile: ./basic/Taskfile.yml
+    dir: ./basic
 
 tasks:
   # example cleanup
@@ -11,9 +16,6 @@ tasks:
     silent: true
     cmds:
       - echo 'example cleaning...'
-      - rm -rf basic/sfn/sfn
-      - rm -rf basic/source/source
-      - rm -rf basic/zipper/zipper
       - rm -rf multi-stream-fn/source/source
       - rm -rf multi-stream-fn/stream-fn-1/fn1
       - rm -rf multi-stream-fn/stream-fn-2/fn2
@@ -24,348 +26,363 @@ tasks:
       - rm -rf same-stream-fn/stream-fn/fn2
       - rm -rf same-stream-fn/zipper/zipper
       - echo 'example clean.'
-  # basic example
-  basic:
-    desc: run basic example
-    deps: [basic-zipper,basic-source,basic-sfn]
-    cmds:
-      - echo 'basic example'
 
-  basic-source:
-    desc: run basic source example
-    deps: [basic-source-build]
-    dir: "basic/source"
-    cmds:
-      - "./source{{exeExt}}"
-    env:
-      YOMO_ENABLE_DEBUG: true
-      YOMO_LOG_LEVEL: error
+  ############## basic has migrated to ./basic/Taskfile.yml ##############
+  # # basic example
+  # basic:
+  #   desc: run basic example
+  #   deps: [basic-zipper,basic-source,basic-flow]
+  #   cmds:
+  #     - echo 'basic example'
 
-  basic-source-build:
-    desc: build basic source example
-    dir: "basic/source"
-    cmds:
-      - echo "basic source building..."
-      - "go build -o source{{exeExt}} main.go"
-      - echo "basic source built."
-    silent: false
+  # basic-source:
+  #   desc: run basic source example
+  #   deps: [basic-source-build]
+  #   dir: "basic/source"
+  #   cmds:
+  #     - "./source{{exeExt}}"
+  #   env:
+  #     YOMO_ENABLE_DEBUG: true
+  #     YOMO_LOG_LEVEL: error
 
-  basic-zipper:
-    desc: run basic zipper service
-    deps: [basic-zipper-build]
-    dir: "basic/zipper"
-    cmds:
-      # - "yomo serve -v -c workflow.yaml"
-      - "./zipper{{exeExt}}"
-    env:
-      YOMO_ENABLE_DEBUG: true
-      YOMO_LOG_LEVEL: error
-      YOMO_ADDR: "localhost:9000"
-      YOMO_DOWNSTREAM_ADDR: "localhost:9001"
+  # basic-source-build:
+  #   desc: build basic source example
+  #   dir: "basic/source"
+  #   cmds:
+  #     - echo "basic source building..."
+  #     - "go build -o source{{exeExt}} main.go"
+  #     - echo "basic source built."
+  #   silent: false
 
-  basic-downstream-zipper:
-    desc: run basic zipper downstream service
-    deps: [basic-zipper-build]
-    dir: "basic/zipper"
-    cmds:
-      # - "yomo serve -v -c workflow.yaml"
-      - "./zipper{{exeExt}}"
-    env:
-      YOMO_ENABLE_DEBUG: true
-      YOMO_LOG_LEVEL: info
-      YOMO_ADDR: "localhost:9001"
+  # basic-zipper:
+  #   desc: run basic zipper service
+  #   deps: [basic-zipper-build]
+  #   dir: "basic/zipper"
+  #   cmds:
+  #     # - "yomo serve -v -c workflow.yaml"
+  #     - "./zipper{{exeExt}}"
+  #   env:
+  #     YOMO_ENABLE_DEBUG: true
+  #     YOMO_LOG_LEVEL: error
+  #     YOMO_ADDR: "localhost:9000"
+  #     YOMO_DOWNSTREAM_ADDR: "localhost:9001"
 
-  basic-downstream-source:
-    desc: run basic downstream source example
-    deps: [basic-source-build]
-    dir: "basic/source"
-    cmds:
-      - "./source{{exeExt}}"
-    env:
-      YOMO_ENABLE_DEBUG: true
-      YOMO_LOG_LEVEL: error
-      YOMO_ADDR: "localhost:9001"
+  # basic-downstream-zipper:
+  #   desc: run basic zipper downstream service
+  #   deps: [basic-zipper-build]
+  #   dir: "basic/zipper"
+  #   cmds:
+  #     # - "yomo serve -v -c workflow.yaml"
+  #     - "./zipper{{exeExt}}"
+  #   env:
+  #     YOMO_ENABLE_DEBUG: true
+  #     YOMO_LOG_LEVEL: info
+  #     YOMO_ADDR: "localhost:9001"
 
-  basic-downstream-sfn:
-    desc: run basic downstream stream function
-    deps: [basic-sfn-build]
-    dir: "basic/sfn"
-    cmds:
-      - "./sfn{{exeExt}}"
-    env:
-      YOMO_ENABLE_DEBUG: true
-      YOMO_LOG_LEVEL: error
-      YOMO_ADDR: "localhost:9001"
+  # basic-downstream-source:
+  #   desc: run basic downstream source example
+  #   deps: [basic-source-build]
+  #   dir: "basic/source"
+  #   cmds:
+  #     - "./source{{exeExt}}"
+  #   env:
+  #     YOMO_ENABLE_DEBUG: true
+  #     YOMO_LOG_LEVEL: error
+  #     YOMO_ADDR: "localhost:9001"
 
+  # basic-downstream-flow:
+  #   desc: run basic downstream flow stream function
+  #   deps: [basic-flow-build]
+  #   dir: "basic/flow"
+  #   cmds:
+  #     - "./flow{{exeExt}}"
+  #   env:
+  #     YOMO_ENABLE_DEBUG: true
+  #     YOMO_LOG_LEVEL: error
+  #     YOMO_ADDR: "localhost:9001"
 
-  basic-zipper-build:
-    desc: build basic zipper example
-    dir: "basic/zipper"
-    cmds:
-      - echo "basic zipper building..."
-      - "go build -o zipper{{exeExt}} main.go"
-      - echo "basic zipper built."
-    silent: false
+  # basic-zipper-build:
+  #   desc: build basic zipper example
+  #   dir: "basic/zipper"
+  #   cmds:
+  #     - echo "basic zipper building..."
+  #     - "go build -o zipper{{exeExt}} main.go"
+  #     - echo "basic zipper built."
+  #   silent: false
 
-  basic-sfn:
-    desc: run basic stream function
-    deps: [basic-sfn-build]
-    dir: "basic/sfn"
-    cmds:
-      - "./sfn{{exeExt}}"
-    env:
-      YOMO_ENABLE_DEBUG: true
-      YOMO_LOG_LEVEL: error
+  # basic-flow:
+  #   desc: run basic flow stream function
+  #   deps: [basic-flow-build]
+  #   dir: "basic/flow"
+  #   cmds:
+  #     - "./flow{{exeExt}}"
+  #   env:
+  #     YOMO_ENABLE_DEBUG: true
+  #     YOMO_LOG_LEVEL: error
 
-  basic-sfn-build:
-    desc: build basic stream function
-    dir: "basic/sfn"
-    cmds:
-      - echo "basic sfn building..."
-      - "go build -o sfn{{exeExt}} main.go"
-      - echo "basic sfn built."
-    silent: false
+  # basic-flow-build:
+  #   desc: build basic flow stream function
+  #   dir: "basic/flow"
+  #   cmds:
+  #     - echo "basic flow building..."
+  #     - "go build -o flow{{exeExt}} main.go"
+  #     - echo "basic flow built."
+  #   silent: false
 
-  # multi stream function example 
-  multi-stream-fn:
-    desc: run multi stream function example
-    deps: [multi-stream-fn-zipper,multi-stream-fn-source,multi-stream-fn-1,multi-stream-fn-2,multi-stream-fn-3]
-    cmds:
-      - echo 'multi stream function example'
+  ############## need to rewrite ##############
+  # # multi stream function example
+  # multi-stream-fn:
+  #   desc: run multi stream function example
+  #   deps:
+  #     [
+  #       multi-stream-fn-zipper,
+  #       multi-stream-fn-source,
+  #       multi-stream-fn-1,
+  #       multi-stream-fn-2,
+  #       multi-stream-fn-3,
+  #     ]
+  #   cmds:
+  #     - echo 'multi stream function example'
 
-  multi-stream-fn-source:
-    desc: run multi stream function example
-    deps: [multi-stream-fn-source-build]
-    dir: "multi-stream-fn/source"
-    cmds:
-      - "./source{{exeExt}}"
-    env:
-      YOMO_ENABLE_DEBUG: false
-      YOMO_LOG_LEVEL: info
+  # multi-stream-fn-source:
+  #   desc: run multi stream function example
+  #   deps: [multi-stream-fn-source-build]
+  #   dir: "multi-stream-fn/source"
+  #   cmds:
+  #     - "./source{{exeExt}}"
+  #   env:
+  #     YOMO_ENABLE_DEBUG: false
+  #     YOMO_LOG_LEVEL: info
 
-  multi-stream-fn-source-build:
-    desc: build multi stream function source example
-    dir: "multi-stream-fn/source"
-    cmds:
-      - echo "multi stream function source building..."
-      - "go build -o source{{exeExt}} main.go"
-      - echo "multi stream function source built."
-    silent: false
+  # multi-stream-fn-source-build:
+  #   desc: build multi stream function source example
+  #   dir: "multi-stream-fn/source"
+  #   cmds:
+  #     - echo "multi stream function source building..."
+  #     - "go build -o source{{exeExt}} main.go"
+  #     - echo "multi stream function source built."
+  #   silent: false
 
-  multi-stream-fn-zipper:
-    desc: run multi stream function zipper service
-    deps: [multi-stream-fn-zipper-build]
-    dir: "multi-stream-fn/zipper"
-    cmds:
-      - "./zipper{{exeExt}}"
-    env:
-      YOMO_ENABLE_DEBUG: false
-      YOMO_LOG_LEVEL: info
+  # multi-stream-fn-zipper:
+  #   desc: run multi stream function zipper service
+  #   deps: [multi-stream-fn-zipper-build]
+  #   dir: "multi-stream-fn/zipper"
+  #   cmds:
+  #     - "./zipper{{exeExt}}"
+  #   env:
+  #     YOMO_ENABLE_DEBUG: false
+  #     YOMO_LOG_LEVEL: info
 
-  multi-stream-fn-zipper-build:
-    desc: build multi stream funcgion zipper example
-    dir: "multi-stream-fn/zipper"
-    cmds:
-      - echo "multi stream function zipper building..."
-      - "go build -o zipper{{exeExt}} main.go"
-      - echo "mult stream function zipper built."
-    silent: false
+  # multi-stream-fn-zipper-build:
+  #   desc: build multi stream funcgion zipper example
+  #   dir: "multi-stream-fn/zipper"
+  #   cmds:
+  #     - echo "multi stream function zipper building..."
+  #     - "go build -o zipper{{exeExt}} main.go"
+  #     - echo "mult stream function zipper built."
+  #   silent: false
 
-  multi-stream-fn-1:
-    desc: run multi stream function 1 
-    deps: [multi-stream-fn-1-build]
-    dir: "multi-stream-fn/stream-fn-1"
-    cmds:
-      - "./fn1{{exeExt}}"
-    env:
-      YOMO_ENABLE_DEBUG: false
-      YOMO_LOG_LEVEL: info
+  # multi-stream-fn-1:
+  #   desc: run multi stream function 1
+  #   deps: [multi-stream-fn-1-build]
+  #   dir: "multi-stream-fn/stream-fn-1"
+  #   cmds:
+  #     - "./fn1{{exeExt}}"
+  #   env:
+  #     YOMO_ENABLE_DEBUG: false
+  #     YOMO_LOG_LEVEL: info
 
-  multi-stream-fn-1-build:
-    desc: build multi stream function 1
-    dir: "multi-stream-fn/stream-fn-1"
-    cmds:
-      - echo "fn1 building..."
-      - "go build -o fn1{{exeExt}} app.go"
-      - echo "fn1 built."
-    silent: false
+  # multi-stream-fn-1-build:
+  #   desc: build multi stream function 1
+  #   dir: "multi-stream-fn/stream-fn-1"
+  #   cmds:
+  #     - echo "fn1 building..."
+  #     - "go build -o fn1{{exeExt}} app.go"
+  #     - echo "fn1 built."
+  #   silent: false
 
-  multi-stream-fn-2:
-    desc: run multi stream function 2 
-    deps: [multi-stream-fn-2-build]
-    dir: "multi-stream-fn/stream-fn-2"
-    cmds:
-      - "./fn2{{exeExt}}"
-    env:
-      YOMO_ENABLE_DEBUG: false
-      YOMO_LOG_LEVEL: info
+  # multi-stream-fn-2:
+  #   desc: run multi stream function 2
+  #   deps: [multi-stream-fn-2-build]
+  #   dir: "multi-stream-fn/stream-fn-2"
+  #   cmds:
+  #     - "./fn2{{exeExt}}"
+  #   env:
+  #     YOMO_ENABLE_DEBUG: false
+  #     YOMO_LOG_LEVEL: info
 
-  multi-stream-fn-2-build:
-    desc: build multi stream function 2
-    dir: "multi-stream-fn/stream-fn-2"
-    cmds:
-      - echo "fn2 building..."
-      - "go build -o fn2{{exeExt}} app.go"
-      - echo "fn2 built."
-    silent: false
+  # multi-stream-fn-2-build:
+  #   desc: build multi stream function 2
+  #   dir: "multi-stream-fn/stream-fn-2"
+  #   cmds:
+  #     - echo "fn2 building..."
+  #     - "go build -o fn2{{exeExt}} app.go"
+  #     - echo "fn2 built."
+  #   silent: false
 
-  multi-stream-fn-3:
-    desc: run multi stream function 3 
-    deps: [multi-stream-fn-3-build]
-    dir: "multi-stream-fn/stream-fn-3"
-    cmds:
-      - "./fn3{{exeExt}}"
-    env:
-      YOMO_ENABLE_DEBUG: false
-      YOMO_LOG_LEVEL: info
+  # multi-stream-fn-3:
+  #   desc: run multi stream function 3
+  #   deps: [multi-stream-fn-3-build]
+  #   dir: "multi-stream-fn/stream-fn-3"
+  #   cmds:
+  #     - "./fn3{{exeExt}}"
+  #   env:
+  #     YOMO_ENABLE_DEBUG: false
+  #     YOMO_LOG_LEVEL: info
 
-  multi-stream-fn-3-build:
-    desc: build multi stream function 3
-    dir: "multi-stream-fn/stream-fn-3"
-    cmds:
-      - echo "fn3 building..."
-      - "go build -o fn3{{exeExt}} app.go"
-      - echo "fn3 built."
-    silent: false
-  # same-stream-fn example
-  same-stream-fn:
-    desc: run same stream function example
-    deps: [same-stream-fn-zipper,same-stream-fn-source,same-stream-fn-1,same-stream-fn-2]
-    cmds:
-      - echo 'same stream function example'
+  # multi-stream-fn-3-build:
+  #   desc: build multi stream function 3
+  #   dir: "multi-stream-fn/stream-fn-3"
+  #   cmds:
+  #     - echo "fn3 building..."
+  #     - "go build -o fn3{{exeExt}} app.go"
+  #     - echo "fn3 built."
+  #   silent: false
+  # # same-stream-fn example
+  # same-stream-fn:
+  #   desc: run same stream function example
+  #   deps:
+  #     [
+  #       same-stream-fn-zipper,
+  #       same-stream-fn-source,
+  #       same-stream-fn-1,
+  #       same-stream-fn-2,
+  #     ]
+  #   cmds:
+  #     - echo 'same stream function example'
 
-  same-stream-fn-source:
-    desc: run same stream function example
-    deps: [same-stream-fn-source-build]
-    dir: "same-stream-fn/source"
-    cmds:
-      - "./source{{exeExt}}"
-    env:
-      YOMO_ENABLE_DEBUG: false
-      YOMO_LOG_LEVEL: info
+  # same-stream-fn-source:
+  #   desc: run same stream function example
+  #   deps: [same-stream-fn-source-build]
+  #   dir: "same-stream-fn/source"
+  #   cmds:
+  #     - "./source{{exeExt}}"
+  #   env:
+  #     YOMO_ENABLE_DEBUG: false
+  #     YOMO_LOG_LEVEL: info
 
-  same-stream-fn-source-build:
-    desc: build same stream function source example
-    dir: "same-stream-fn/source"
-    cmds:
-      - echo "same stream function source building..."
-      - "go build -o source{{exeExt}} main.go"
-      - echo "same stream function source built."
-    silent: false
+  # same-stream-fn-source-build:
+  #   desc: build same stream function source example
+  #   dir: "same-stream-fn/source"
+  #   cmds:
+  #     - echo "same stream function source building..."
+  #     - "go build -o source{{exeExt}} main.go"
+  #     - echo "same stream function source built."
+  #   silent: false
 
-  same-stream-fn-zipper:
-    desc: run same stream function zipper service
-    deps: [same-stream-fn-zipper-build]
-    dir: "same-stream-fn/zipper"
-    cmds:
-      - "./zipper{{exeExt}}"
-    env:
-      YOMO_ENABLE_DEBUG: true
-      YOMO_LOG_LEVEL: info
+  # same-stream-fn-zipper:
+  #   desc: run same stream function zipper service
+  #   deps: [same-stream-fn-zipper-build]
+  #   dir: "same-stream-fn/zipper"
+  #   cmds:
+  #     - "./zipper{{exeExt}}"
+  #   env:
+  #     YOMO_ENABLE_DEBUG: true
+  #     YOMO_LOG_LEVEL: info
 
-  same-stream-fn-zipper-build:
-    desc: build same stream funcgion zipper example
-    dir: "same-stream-fn/zipper"
-    cmds:
-      - echo "same stream function zipper building..."
-      - "go build -o zipper{{exeExt}} main.go"
-      - echo "same stream function zipper built."
-    silent: false
+  # same-stream-fn-zipper-build:
+  #   desc: build same stream funcgion zipper example
+  #   dir: "same-stream-fn/zipper"
+  #   cmds:
+  #     - echo "same stream function zipper building..."
+  #     - "go build -o zipper{{exeExt}} main.go"
+  #     - echo "same stream function zipper built."
+  #   silent: false
 
-  same-stream-fn-1:
-    desc: run same stream function  
-    deps: [same-stream-fn-build]
-    dir: "same-stream-fn/stream-fn"
-    cmds:
-      - "./fn1{{exeExt}}"
-    env:
-      YOMO_ENABLE_DEBUG: false
-      YOMO_LOG_LEVEL: info
+  # same-stream-fn-1:
+  #   desc: run same stream function
+  #   deps: [same-stream-fn-build]
+  #   dir: "same-stream-fn/stream-fn"
+  #   cmds:
+  #     - "./fn1{{exeExt}}"
+  #   env:
+  #     YOMO_ENABLE_DEBUG: false
+  #     YOMO_LOG_LEVEL: info
 
-  same-stream-fn-build:
-    desc: build same stream function 3
-    dir: "same-stream-fn/stream-fn"
-    cmds:
-      - echo "fn building..."
-      - "go build -o fn1{{exeExt}} app.go"
-      - "cp ./fn1 ./fn2"
-      - echo "fn built."
-    silent: false
+  # same-stream-fn-build:
+  #   desc: build same stream function 3
+  #   dir: "same-stream-fn/stream-fn"
+  #   cmds:
+  #     - echo "fn building..."
+  #     - "go build -o fn1{{exeExt}} app.go"
+  #     - "cp ./fn1 ./fn2"
+  #     - echo "fn built."
+  #   silent: false
 
-  same-stream-fn-2:
-    desc: run same stream function  
-    deps: [same-stream-fn-build]
-    dir: "same-stream-fn/stream-fn"
-    cmds:
-      - "./fn2{{exeExt}}"
-    env:
-      YOMO_ENABLE_DEBUG: false
-      YOMO_LOG_LEVEL: info
+  # same-stream-fn-2:
+  #   desc: run same stream function
+  #   deps: [same-stream-fn-build]
+  #   dir: "same-stream-fn/stream-fn"
+  #   cmds:
+  #     - "./fn2{{exeExt}}"
+  #   env:
+  #     YOMO_ENABLE_DEBUG: false
+  #     YOMO_LOG_LEVEL: info
 
-  # multi zipper example 
-  multi-zipper:
-    desc: run example
-    deps: [multi-zipper-build]
-    cmds: 
-      - task: multi-zipper-services
+  # # multi zipper example
+  # multi-zipper:
+  #   desc: run example
+  #   deps: [multi-zipper-build]
+  #   cmds:
+  #     - task: multi-zipper-services
 
-  multi-zipper-services:
-    desc: yomo services
-    deps: [multi-zipper-2, multi-zipper-sfn, multi-zipper-1, multi-zipper-source]
+  # multi-zipper-services:
+  #   desc: yomo services
+  #   deps:
+  #     [multi-zipper-2, multi-zipper-sfn, multi-zipper-1, multi-zipper-source]
 
+  # multi-zipper-build:
+  #   run: once
+  #   desc: go build
+  #   dir: "multi-zipper"
+  #   cmds:
+  #     - rm -rf bin
+  #     - mkdir -p bin
+  #     - go build -o bin/source source/source.go
+  #     - go build -o bin/zipper-2 zipper-2/zipper_2.go
+  #     - go build -o bin/zipper-1 zipper-1/zipper_1.go
+  #     - go build -o bin/sfn sfn/sfn_echo.go
+  #     - task: multi-zipper-copy
 
-  multi-zipper-build:
-    run: once
-    desc: go build
-    dir: "multi-zipper"
-    cmds:
-      - rm -rf bin
-      - mkdir -p bin
-      - go build -o bin/source source/source.go
-      - go build -o bin/zipper-2 zipper-2/zipper_2.go
-      - go build -o bin/zipper-1 zipper-1/zipper_1.go
-      - go build -o bin/sfn sfn/sfn_echo.go
-      - task: multi-zipper-copy
+  # multi-zipper-copy:
+  #   desc: copy workflow configs
+  #   dir: "multi-zipper"
+  #   cmds:
+  #     - cp zipper-1/*.yaml bin/.
+  #     - cp zipper-2/*.yaml bin/.
 
-  multi-zipper-copy:
-    desc: copy workflow configs
-    dir: "multi-zipper"
-    cmds:
-      - cp zipper-1/*.yaml bin/.
-      - cp zipper-2/*.yaml bin/.
+  # multi-zipper-2:
+  #   desc: start zipper service 2
+  #   dir: "multi-zipper/bin"
+  #   env:
+  #     YOMO_ENABLE_DEBUG: false
+  #     YOMO_LOG_LEVEL: debug
+  #   cmds:
+  #     - ./zipper-2
 
-  multi-zipper-2:
-    desc: start zipper service 2
-    dir: "multi-zipper/bin"
-    env:
-      YOMO_ENABLE_DEBUG: false
-      YOMO_LOG_LEVEL: debug
-    cmds:
-      - ./zipper-2
+  # multi-zipper-1:
+  #   desc: start zipper service 1
+  #   dir: "multi-zipper/bin"
+  #   env:
+  #     YOMO_ENABLE_DEBUG: false
+  #     YOMO_LOG_LEVEL: debug
+  #   cmds:
+  #     - ./zipper-1
 
-  multi-zipper-1:
-    desc: start zipper service 1
-    dir: "multi-zipper/bin"
-    env:
-      YOMO_ENABLE_DEBUG: false
-      YOMO_LOG_LEVEL: debug
-    cmds:
-      - ./zipper-1
+  # multi-zipper-sfn:
+  #   desc: start stream function
+  #   dir: "multi-zipper/bin"
+  #   env:
+  #     YOMO_ENABLE_DEBUG: false
+  #     YOMO_LOG_LEVEL: debug
+  #   cmds:
+  #     - ./sfn
 
-  multi-zipper-sfn:
-    desc: start stream function
-    dir: "multi-zipper/bin"
-    env:
-      YOMO_ENABLE_DEBUG: false
-      YOMO_LOG_LEVEL: debug
-    cmds:
-      - ./sfn
-
-  multi-zipper-source:
-    desc: run source
-    dir: "multi-zipper/bin"
-    env:
-      YOMO_ENABLE_DEBUG: false
-      YOMO_LOG_LEVEL: debug
-    cmds:
-      - ./source
+  # multi-zipper-source:
+  #   desc: run source
+  #   dir: "multi-zipper/bin"
+  #   env:
+  #     YOMO_ENABLE_DEBUG: false
+  #     YOMO_LOG_LEVEL: debug
+  #   cmds:
+  #     - ./source

--- a/example/Taskfile.yml
+++ b/example/Taskfile.yml
@@ -16,6 +16,9 @@ tasks:
     silent: true
     cmds:
       - echo 'example cleaning...'
+      # - rm -rf basic/flow/flow
+      # - rm -rf basic/source/source
+      # - rm -rf basic/zipper/zipper
       - rm -rf multi-stream-fn/source/source
       - rm -rf multi-stream-fn/stream-fn-1/fn1
       - rm -rf multi-stream-fn/stream-fn-2/fn2

--- a/example/basic/Taskfile.yml
+++ b/example/basic/Taskfile.yml
@@ -1,10 +1,28 @@
 # https://taskfile.dev
 
-version: '3'
+version: "3"
 
-output: 'prefixed'
+output: "prefixed"
 
 tasks:
+  run:
+    desc: run with downstream
+    deps:
+      [
+        source,
+        flow,
+        zipper,
+        downstream-zipper,
+        downstream-source,
+        downstream-flow,
+      ]
+
+  run-only-basic:
+    desc: only run the very basic example
+    deps: [zipper, source, flow]
+    cmds:
+      - echo 'basic example run'
+
   # example cleanup
   clean:
     desc: example cleanup
@@ -12,7 +30,6 @@ tasks:
     cmds:
       - echo 'example cleaning...'
       - rm -rf bin
-      - echo 'example clean.'
 
   build:
     desc: build source, flow and zipper
@@ -22,30 +39,19 @@ tasks:
 
   source-build:
     desc: build basic source example
-    dir: "source"
     cmds:
-      - "go build -o ../bin/source{{exeExt}} main.go"
-    silent: false
+      - "go build -o ./bin/source{{exeExt}} source/main.go"
 
   zipper-build:
     desc: build basic zipper example
-    dir: "zipper"
     cmds:
-      - "go build -o ../bin/zipper{{exeExt}} main.go"
-    silent: false
+      - "go build -o ./bin/zipper{{exeExt}} zipper/main.go"
+      - "cp zipper/workflow.yaml ./bin/."
 
   flow-build:
     desc: build basic flow stream function
-    dir: "flow"
     cmds:
-      - "go build -o ../bin/flow{{exeExt}} main.go"
-    silent: false
-
-  basic:
-    desc: run basic example
-    deps: [zipper, source, flow]
-    cmds:
-      - echo 'basic example run'
+      - "go build -o ./bin/flow{{exeExt}} flow/main.go"
 
   source:
     desc: run basic source example
@@ -68,10 +74,11 @@ tasks:
   zipper:
     desc: run basic zipper service
     deps: [zipper-build]
+    dir: bin
     cmds:
-      - "yomo serve -v -c zipper/workflow.yaml"
-      # - "cp zipper/workflow.yaml ./bin/."
-      # - "./bin/zipper{{exeExt}}"
+      # - "yomo serve -v -c zipper/workflow.yaml"
+      - "cp ../zipper/workflow.yaml ."
+      - "./zipper{{exeExt}}"
     env:
       YOMO_ENABLE_DEBUG: true
       YOMO_LOG_LEVEL: error
@@ -81,9 +88,8 @@ tasks:
   downstream-zipper:
     desc: run basic zipper downstream service
     deps: [zipper-build]
-    dir: "zipper"
+    dir: "bin"
     cmds:
-      # - "yomo serve -v -c workflow.yaml"
       - "./zipper{{exeExt}}"
     env:
       YOMO_ENABLE_DEBUG: true
@@ -93,7 +99,7 @@ tasks:
   downstream-source:
     desc: run basic downstream source example
     deps: [source-build]
-    dir: "source"
+    dir: "bin"
     cmds:
       - "./source{{exeExt}}"
     env:
@@ -104,7 +110,7 @@ tasks:
   downstream-flow:
     desc: run basic downstream flow stream function
     deps: [flow-build]
-    dir: "flow"
+    dir: "bin"
     cmds:
       - "./flow{{exeExt}}"
     env:

--- a/example/basic/Taskfile.yml
+++ b/example/basic/Taskfile.yml
@@ -1,0 +1,113 @@
+# https://taskfile.dev
+
+version: '3'
+
+output: 'prefixed'
+
+tasks:
+  # example cleanup
+  clean:
+    desc: example cleanup
+    silent: true
+    cmds:
+      - echo 'example cleaning...'
+      - rm -rf bin
+      - echo 'example clean.'
+
+  build:
+    desc: build source, flow and zipper
+    deps: [source-build, flow-build, zipper-build]
+    cmds:
+      - echo 'building done'
+
+  source-build:
+    desc: build basic source example
+    dir: "source"
+    cmds:
+      - "go build -o ../bin/source{{exeExt}} main.go"
+    silent: false
+
+  zipper-build:
+    desc: build basic zipper example
+    dir: "zipper"
+    cmds:
+      - "go build -o ../bin/zipper{{exeExt}} main.go"
+    silent: false
+
+  flow-build:
+    desc: build basic flow stream function
+    dir: "flow"
+    cmds:
+      - "go build -o ../bin/flow{{exeExt}} main.go"
+    silent: false
+
+  basic:
+    desc: run basic example
+    deps: [zipper, source, flow]
+    cmds:
+      - echo 'basic example run'
+
+  source:
+    desc: run basic source example
+    deps: [source-build]
+    cmds:
+      - "./bin/source{{exeExt}}"
+    env:
+      YOMO_ENABLE_DEBUG: true
+      YOMO_LOG_LEVEL: error
+
+  flow:
+    desc: run basic flow stream function
+    deps: [flow-build]
+    cmds:
+      - "./bin/flow{{exeExt}}"
+    env:
+      YOMO_ENABLE_DEBUG: true
+      YOMO_LOG_LEVEL: error
+
+  zipper:
+    desc: run basic zipper service
+    deps: [zipper-build]
+    cmds:
+      - "yomo serve -v -c zipper/workflow.yaml"
+      # - "cp zipper/workflow.yaml ./bin/."
+      # - "./bin/zipper{{exeExt}}"
+    env:
+      YOMO_ENABLE_DEBUG: true
+      YOMO_LOG_LEVEL: error
+      YOMO_ADDR: "localhost:9000"
+      YOMO_DOWNSTREAM_ADDR: "localhost:9001"
+
+  downstream-zipper:
+    desc: run basic zipper downstream service
+    deps: [zipper-build]
+    dir: "zipper"
+    cmds:
+      # - "yomo serve -v -c workflow.yaml"
+      - "./zipper{{exeExt}}"
+    env:
+      YOMO_ENABLE_DEBUG: true
+      YOMO_LOG_LEVEL: info
+      YOMO_ADDR: "localhost:9001"
+
+  downstream-source:
+    desc: run basic downstream source example
+    deps: [source-build]
+    dir: "source"
+    cmds:
+      - "./source{{exeExt}}"
+    env:
+      YOMO_ENABLE_DEBUG: true
+      YOMO_LOG_LEVEL: error
+      YOMO_ADDR: "localhost:9001"
+
+  downstream-flow:
+    desc: run basic downstream flow stream function
+    deps: [flow-build]
+    dir: "flow"
+    cmds:
+      - "./flow{{exeExt}}"
+    env:
+      YOMO_ENABLE_DEBUG: true
+      YOMO_LOG_LEVEL: error
+      YOMO_ADDR: "localhost:9001"

--- a/example/basic/Taskfile.yml
+++ b/example/basic/Taskfile.yml
@@ -10,16 +10,16 @@ tasks:
     deps:
       [
         source,
-        flow,
+        sfn,
         zipper,
         downstream-zipper,
         downstream-source,
-        downstream-flow,
+        downstream-sfn,
       ]
 
   run-only-basic:
     desc: only run the very basic example
-    deps: [zipper, source, flow]
+    deps: [zipper, source, sfn]
     cmds:
       - echo 'basic example run'
 
@@ -32,8 +32,8 @@ tasks:
       - rm -rf bin
 
   build:
-    desc: build source, flow and zipper
-    deps: [source-build, flow-build, zipper-build]
+    desc: build source, sfn and zipper
+    deps: [source-build, sfn-build, zipper-build]
     cmds:
       - echo 'building done'
 
@@ -48,10 +48,10 @@ tasks:
       - "go build -o ./bin/zipper{{exeExt}} zipper/main.go"
       - "cp zipper/workflow.yaml ./bin/."
 
-  flow-build:
-    desc: build basic flow stream function
+  sfn-build:
+    desc: build basic stream function
     cmds:
-      - "go build -o ./bin/flow{{exeExt}} flow/main.go"
+      - "go build -o ./bin/sfn{{exeExt}} sfn/main.go"
 
   source:
     desc: run basic source example
@@ -62,11 +62,11 @@ tasks:
       YOMO_ENABLE_DEBUG: true
       YOMO_LOG_LEVEL: error
 
-  flow:
-    desc: run basic flow stream function
-    deps: [flow-build]
+  sfn:
+    desc: run basic stream function
+    deps: [sfn-build]
     cmds:
-      - "./bin/flow{{exeExt}}"
+      - "./bin/sfn{{exeExt}}"
     env:
       YOMO_ENABLE_DEBUG: true
       YOMO_LOG_LEVEL: error
@@ -107,12 +107,12 @@ tasks:
       YOMO_LOG_LEVEL: error
       YOMO_ADDR: "localhost:9001"
 
-  downstream-flow:
-    desc: run basic downstream flow stream function
-    deps: [flow-build]
+  downstream-sfn:
+    desc: run basic downstream stream function
+    deps: [sfn-build]
     dir: "bin"
     cmds:
-      - "./flow{{exeExt}}"
+      - "./sfn{{exeExt}}"
     env:
       YOMO_ENABLE_DEBUG: true
       YOMO_LOG_LEVEL: error

--- a/example/basic/Taskfile.yml
+++ b/example/basic/Taskfile.yml
@@ -10,16 +10,16 @@ tasks:
     deps:
       [
         source,
-        sfn,
+        flow,
         zipper,
         downstream-zipper,
         downstream-source,
-        downstream-sfn,
+        downstream-flow,
       ]
 
   run-only-basic:
     desc: only run the very basic example
-    deps: [zipper, source, sfn]
+    deps: [zipper, source, flow]
     cmds:
       - echo 'basic example run'
 
@@ -48,10 +48,32 @@ tasks:
       - "go build -o ./bin/zipper{{exeExt}} zipper/main.go"
       - "cp zipper/workflow.yaml ./bin/."
 
+<<<<<<< HEAD
   sfn-build:
     desc: build basic stream function
+||||||| parent of b933201 (could run task at root dir, ./example dir, and each example dir)
+  flow-build:
+    desc: build basic flow stream function
+    dir: "flow"
+=======
+  flow-build:
+    desc: build basic flow stream function
+>>>>>>> b933201 (could run task at root dir, ./example dir, and each example dir)
     cmds:
+<<<<<<< HEAD
       - "go build -o ./bin/sfn{{exeExt}} sfn/main.go"
+||||||| parent of b933201 (could run task at root dir, ./example dir, and each example dir)
+      - "go build -o ../bin/flow{{exeExt}} main.go"
+    silent: false
+
+  basic:
+    desc: run basic example
+    deps: [zipper, source, flow]
+    cmds:
+      - echo 'basic example run'
+=======
+      - "go build -o ./bin/flow{{exeExt}} flow/main.go"
+>>>>>>> b933201 (could run task at root dir, ./example dir, and each example dir)
 
   source:
     desc: run basic source example
@@ -107,10 +129,22 @@ tasks:
       YOMO_LOG_LEVEL: error
       YOMO_ADDR: "localhost:9001"
 
+<<<<<<< HEAD
   downstream-sfn:
     desc: run basic downstream stream function
     deps: [sfn-build]
     dir: "bin"
+||||||| parent of b933201 (could run task at root dir, ./example dir, and each example dir)
+  downstream-flow:
+    desc: run basic downstream flow stream function
+    deps: [flow-build]
+    dir: "flow"
+=======
+  downstream-flow:
+    desc: run basic downstream flow stream function
+    deps: [flow-build]
+    dir: "bin"
+>>>>>>> b933201 (could run task at root dir, ./example dir, and each example dir)
     cmds:
       - "./sfn{{exeExt}}"
     env:


### PR DESCRIPTION
- separate `Taskfile.yml` to every example project folder, see `example/basic/Taskfile.yml`
- build to `example/xxx/bin` directory, and ignore `bin/` in `.gitignore`, so there will be no chance push build result to git

If this is ok, I will refactory other examples in this way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yomorun/yomo/286)
<!-- Reviewable:end -->
