### PR TITLE
refactor: do not print frame raw bytes to logger, maybe it very large, take performance down in debug mode.

### DIFF
--- a/core/server.go
+++ b/core/server.go
@@ -191,7 +191,8 @@ func (s *Server) handleSession(c *Context) {
 		}
 
 		frameType := f.Type()
-		logger.Debugf("%stype=%s, frame=%# x", ServerLogPrefix, frameType, f.Encode())
+		// f maybe very large, do not output it to logger.
+		logger.Debugf("%stype=%s, len(frame)=%d", ServerLogPrefix, frameType, len(f.Encode()))
 		// add frame to context
 		c := c.WithFrame(f)
 


### PR DESCRIPTION
Usefull when `DataFrame` is very large.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yomorun/yomo/288)
<!-- Reviewable:end -->
