### PR TITLE
Fix return nil when encounter a non-nil error

### DIFF
--- a/core/server.go
+++ b/core/server.go
@@ -76,7 +76,7 @@ func (s *Server) ListenAndServe(ctx context.Context, addr string) error {
 	}
 	udpAddr, err := net.ResolveUDPAddr("udp", addr)
 	if err != nil {
-		return nil
+		return err
 	}
 	conn, err := net.ListenUDP("udp", udpAddr)
 	if err != nil {


### PR DESCRIPTION
I believe it might be a careless bug as it returns nil even if there is a non-error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yomorun/yomo/345)
<!-- Reviewable:end -->
