### PR TITLE
fix(client):  conn nil pointer panic close

### DIFF
--- a/core/client.go
+++ b/core/client.go
@@ -226,7 +226,10 @@ func (c *Client) Close() error {
 		return nil
 	}
 
-	c.conn.CloseWithError(yerr.ErrorCodeClientAbort.To(), "client ask to close")
+	if c.conn != nil {
+		c.conn.CloseWithError(yerr.ErrorCodeClientAbort.To(), "client ask to close")
+	}
+
 	return c.close()
 }
 


### PR DESCRIPTION
`c.conn` is nil if quic dial failed, there will panic when call `client.Close()`