### PR TITLE
refactor: introduce SourceOption and SfnOption

### DIFF
--- a/example/9-cli/source/main.go
+++ b/example/9-cli/source/main.go
@@ -18,7 +18,7 @@ type noiseData struct {
 
 func main() {
 	// connect to YoMo-Zipper.
-	opts := []yomo.Option{}
+	opts := []yomo.SourceOption{}
 	if credential := os.Getenv("YOMO_CREDENTIAL"); credential != "" {
 		opts = append(opts, yomo.WithCredential(credential))
 	}

--- a/options.go
+++ b/options.go
@@ -2,11 +2,34 @@ package yomo
 
 import (
 	"github.com/yomorun/yomo/core"
-	"github.com/yomorun/yomo/core/frame"
-	"golang.org/x/exp/slog"
 )
 
-// Option is a function that applies a YoMo-Client option.
+type (
+	// SourceOption is option for the Source.
+	SourceOption = core.ClientOption
+
+	// SfnOption is option for the SFN.
+	SfnOption = core.ClientOption
+)
+
+var (
+	// WithObserveDataTags sets the list of data tags for the Source or SFN.
+	WithObserveDataTags = core.WithObserveDataTags
+
+	// WithCredential sets the credential method for the Source or SFN.
+	WithCredential = core.WithCredential
+
+	// WithClientTLSConfig sets tls config for the Source or SFN.
+	WithClientTLSConfig = core.WithClientTLSConfig
+
+	// WithClientQuicConfig sets quic config for the Source or SFN.
+	WithClientQuicConfig = core.WithClientQuicConfig
+
+	// WithLogger sets logger for the Source or SFN.
+	WithLogger = core.WithLogger
+)
+
+// Option is a function that applies a Zipper option.
 type Option func(o *Options)
 
 // Options are the options for YoMo
@@ -46,36 +69,6 @@ func WithAuth(name string, args ...string) Option {
 		o.ServerOptions = append(
 			o.ServerOptions,
 			core.WithAuth(name, args...),
-		)
-	}
-}
-
-// WithCredential sets the client credential method (used by client)
-func WithCredential(payload string) Option {
-	return func(o *Options) {
-		o.ClientOptions = append(
-			o.ClientOptions,
-			core.WithCredential(payload),
-		)
-	}
-}
-
-// WithObserveDataTags sets client data tag list.
-func WithObserveDataTags(tags ...frame.Tag) Option {
-	return func(o *Options) {
-		o.ClientOptions = append(
-			o.ClientOptions,
-			core.WithObserveDataTags(tags...),
-		)
-	}
-}
-
-// WithLogger sets the client logger
-func WithLogger(logger *slog.Logger) Option {
-	return func(o *Options) {
-		o.ClientOptions = append(
-			o.ClientOptions,
-			core.WithLogger(logger),
 		)
 	}
 }

--- a/sfn.go
+++ b/sfn.go
@@ -27,9 +27,8 @@ type StreamFunction interface {
 }
 
 // NewStreamFunction create a stream function.
-func NewStreamFunction(name, zipperAddr string, opts ...Option) StreamFunction {
-	options := NewOptions(opts...)
-	client := core.NewClient(name, core.ClientTypeStreamFunction, options.ClientOptions...)
+func NewStreamFunction(name, zipperAddr string, opts ...SfnOption) StreamFunction {
+	client := core.NewClient(name, core.ClientTypeStreamFunction, opts...)
 	sfn := &streamFunction{
 		name:            name,
 		zipperAddr:      zipperAddr,

--- a/source.go
+++ b/source.go
@@ -39,9 +39,8 @@ type yomoSource struct {
 var _ Source = &yomoSource{}
 
 // NewSource create a yomo-source
-func NewSource(name, zipperAddr string, opts ...Option) Source {
-	options := NewOptions(opts...)
-	client := core.NewClient(name, core.ClientTypeSource, options.ClientOptions...)
+func NewSource(name, zipperAddr string, opts ...SourceOption) Source {
+	client := core.NewClient(name, core.ClientTypeSource, opts...)
 
 	return &yomoSource{
 		name:       name,

--- a/zipper.go
+++ b/zipper.go
@@ -93,9 +93,8 @@ func NewZipper(conf string) (Zipper, error) {
 }
 
 // NewDownstreamZipper create a zipper descriptor for downstream zipper.
-func NewDownstreamZipper(name, addr string, opts ...Option) Zipper {
-	options := NewOptions(opts...)
-	client := core.NewClient(name, core.ClientTypeUpstreamZipper, options.ClientOptions...)
+func NewDownstreamZipper(name, addr string, opts ...core.ClientOption) Zipper {
+	client := core.NewClient(name, core.ClientTypeUpstreamZipper, opts...)
 
 	return &zipper{
 		name:   name,
@@ -177,9 +176,9 @@ func (z *zipper) ConfigMesh(url string) error {
 			continue
 		}
 		addr := fmt.Sprintf("%s:%d", downstream.Host, downstream.Port)
-		opts := []Option{}
+		opts := []core.ClientOption{}
 		if downstream.Credential != "" {
-			opts = append(opts, WithCredential(downstream.Credential))
+			opts = append(opts, core.WithCredential(downstream.Credential))
 		}
 		z.AddDownstreamZipper(NewDownstreamZipper(downstream.Name, addr, opts...))
 	}


### PR DESCRIPTION
# Description

The YoMo option now includes the following options for managing different components: SourceOption, SfnOption and Option. Option manages Zipper's option, Each option has a clear division of labor.

## Impact


How to create a stream function.

```go
  sfn := yomo.NewStreamFunction(
      "sfn-2",
      "127.0.0.1:9000",
      yomo.WithObserveDataTags(0x34),
  )
  defer sfn.Close()
```

How to create a source.

```go
  source := yomo.NewSource(
    "yomo-source",
    "127.0.0.1:9000",
    yomo.WithObserveDataTags(0x34, 0x35),
  )
  defer source.Close()
```
