### PR TITLE
fix: client no-block write & connect until succeed

### DIFF
--- a/core/client.go
+++ b/core/client.go
@@ -222,10 +222,6 @@ func (c *Client) processStream(controlStream *ClientControlStream, dataStream Da
 			c.handleFrame(result.frame)
 		case f := <-c.writeFrameChan:
 			err := dataStream.WriteFrame(f)
-			// restore DataFrame.
-			if d, ok := f.(*frame.DataFrame); ok {
-				d.Clean()
-			}
 			c.handleFrameError(err, reconnection)
 		}
 	}

--- a/core/client.go
+++ b/core/client.go
@@ -71,6 +71,7 @@ connect:
 	if err != nil {
 		if c.opts.connectUntilSucceed {
 			c.logger.Error("failed to connect to zipper, trying to reconect", err)
+			time.Sleep(time.Second)
 			goto connect
 		}
 		c.logger.Error("can not connect to zipper", err)

--- a/core/client.go
+++ b/core/client.go
@@ -66,8 +66,13 @@ func NewClient(appName string, connType ClientType, opts ...ClientOption) *Clien
 func (c *Client) Connect(ctx context.Context, addr string) error {
 	c.logger = c.logger.With("zipper_addr", addr)
 
+connect:
 	controlStream, dataStream, err := c.openStream(ctx, addr)
 	if err != nil {
+		if c.opts.connectUntilSucceed {
+			c.logger.Error("failed to connect to zipper, trying to reconect", err)
+			goto connect
+		}
 		c.logger.Error("can not connect to zipper", err)
 		return err
 	}
@@ -92,7 +97,7 @@ func (c *Client) runBackground(ctx context.Context, addr string, controlStream *
 			c.cleanStream(controlStream, ctx.Err())
 			return
 		case <-reconnection:
-		RECONNECT:
+		reconnect:
 			var err error
 			controlStream, dataStream, err = c.openStream(ctx, addr)
 			if err != nil {
@@ -102,7 +107,7 @@ func (c *Client) runBackground(ctx context.Context, addr string, controlStream *
 				}
 				c.logger.Error("reconnect error", err)
 				time.Sleep(time.Second)
-				goto RECONNECT
+				goto reconnect
 			}
 			go c.processStream(controlStream, dataStream, reconnection)
 		}
@@ -111,8 +116,28 @@ func (c *Client) runBackground(ctx context.Context, addr string, controlStream *
 
 // WriteFrame write frame to client.
 func (c *Client) WriteFrame(f frame.Frame) error {
+	if c.opts.nonBlockWrite {
+		return c.nonBlockWriteFrame(f)
+	}
+	return c.blockWriteFrame(f)
+}
+
+// blockWriteFrame writes frames in block mode, guaranteeing that frames are not lost.
+func (c *Client) blockWriteFrame(f frame.Frame) error {
 	c.writeFrameChan <- f
 	return nil
+}
+
+// nonBlockWriteFrame writes frames in non-blocking mode, without guaranteeing that frames will not be lost.
+func (c *Client) nonBlockWriteFrame(f frame.Frame) error {
+	select {
+	case c.writeFrameChan <- f:
+		return nil
+	default:
+		err := errors.New("yomo: client has lost connection")
+		c.logger.Debug("failed to write frame", "frame_type", f.Type().String(), "error", err)
+		return err
+	}
 }
 
 func (c *Client) cleanStream(controlStream *ClientControlStream, err error) {

--- a/core/client_options.go
+++ b/core/client_options.go
@@ -17,11 +17,13 @@ type ClientOption func(*clientOptions)
 
 // clientOptions are the options for YoMo client.
 type clientOptions struct {
-	observeDataTags []frame.Tag
-	quicConfig      *quic.Config
-	tlsConfig       *tls.Config
-	credential      *auth.Credential
-	logger          *slog.Logger
+	observeDataTags     []frame.Tag
+	quicConfig          *quic.Config
+	tlsConfig           *tls.Config
+	credential          *auth.Credential
+	connectUntilSucceed bool
+	nonBlockWrite       bool
+	logger              *slog.Logger
 }
 
 func defaultClientOption() *clientOptions {
@@ -77,6 +79,20 @@ func WithClientTLSConfig(tc *tls.Config) ClientOption {
 func WithClientQuicConfig(qc *quic.Config) ClientOption {
 	return func(o *clientOptions) {
 		o.quicConfig = qc
+	}
+}
+
+// WithConnectUntilSucceed makes client Connect until seccssed.
+func WithConnectUntilSucceed() ClientOption {
+	return func(o *clientOptions) {
+		o.connectUntilSucceed = true
+	}
+}
+
+// WithNonBlockWrite makes client WriteFrame non-blocking.
+func WithNonBlockWrite() ClientOption {
+	return func(o *clientOptions) {
+		o.nonBlockWrite = true
 	}
 }
 

--- a/core/context.go
+++ b/core/context.go
@@ -91,7 +91,7 @@ func newContext(dataStream DataStream, route router.Route, logger *slog.Logger) 
 		c = v.(*Context)
 	}
 
-	c.Logger = logger.With(
+	logger = logger.With(
 		"stream_id", dataStream.ID(),
 		"stream_name", dataStream.Name(),
 		"stream_type", dataStream.StreamType().String(),

--- a/core/frame/data_frame_test.go
+++ b/core/frame/data_frame_test.go
@@ -37,7 +37,6 @@ func TestDataFrameDecode(t *testing.T) {
 		0x80 | byte(TagOfPayloadFrame), 0x09,
 		0x01, 0x1, 0x15, 0x02, 0x04, 0x79, 0x6F, 0x6D, 0x6F}
 	data, err := DecodeToDataFrame(buf)
-	defer data.Clean()
 	assert.NoError(t, err)
 
 	assert.EqualValues(t, 0x15, data.Tag())
@@ -45,21 +44,4 @@ func TestDataFrameDecode(t *testing.T) {
 	assert.EqualValues(t, userDataTag, data.GetDataTag())
 	assert.EqualValues(t, []byte("yomo"), data.GetCarriage())
 	assert.EqualValues(t, true, data.IsBroadcast())
-}
-
-func BenchmarkDataFramePool(b *testing.B) {
-	var (
-		tag     = Tag(0x15)
-		payload = []byte("yomo")
-	)
-
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			prev := NewDataFrame()
-			prev.SetCarriage(tag, payload)
-			prev.SetBroadcast(true)
-
-			prev.Clean()
-		}
-	})
 }

--- a/core/server.go
+++ b/core/server.go
@@ -319,7 +319,7 @@ func (s *Server) handleDataFrame(c *Context) error {
 	// find stream function ids from the route.
 	streamIDs := route.GetForwardRoutes(f.GetDataTag())
 
-	c.Logger.Debug("sfn routing", "sfn_stream_ids", streamIDs, "connector", s.connector.GetSnapshot())
+	c.Logger.Debug("sfn routing", "data_tag", f.GetDataTag(), "sfn_stream_ids", streamIDs, "connector", s.connector.GetSnapshot())
 
 	for _, toID := range streamIDs {
 		stream, ok, err := s.connector.Get(toID)

--- a/zipper.go
+++ b/zipper.go
@@ -95,7 +95,9 @@ func NewZipper(conf string) (Zipper, error) {
 // NewDownstreamZipper create a zipper descriptor for downstream zipper.
 func NewDownstreamZipper(name, addr string, opts ...Option) Zipper {
 	options := NewOptions(opts...)
-	client := core.NewClient(name, core.ClientTypeUpstreamZipper, options.ClientOptions...)
+	// upstreamZipper always try to connect to downstreamZipper.
+	clientOption := append(options.ClientOptions, core.WithConnectUntilSucceed(), core.WithNonBlockWrite())
+	client := core.NewClient(name, core.ClientTypeUpstreamZipper, clientOption...)
 
 	return &zipper{
 		name:   name,


### PR DESCRIPTION
# Description

Add `ConnectUntilSucceed` and `NonBlockWrite`Option for the client.`ConnectUntilSucceed` ensures that the client must successfully `Connect()`, while `NonBlockWrite` returns an error if the client loses its connection instead of waiting for the connection to be restored. `ConnectUntilSucceed` and `NonBlockWrite` are usually used for upstreamZipper in mesh zipper mode.
