### PR TITLE
chore: improve Github release action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: release
 on:
   push:
     tags:
-      - "v*.*.*"
+      - "v*"
   workflow_dispatch:
     inputs:
       logLevel:
@@ -11,139 +11,45 @@ on:
         required: true
         default: 'warning'
 jobs:
-  bina-for-curl-download:
-    name: Make bina.json
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v3
-      - name: Genetate bina.json
-        run: cd ./cli && make bina
-      - name: upload artifacts
-        uses: actions/upload-artifact@master
-        with:
-          name: yomo-artifact
-          path: ./cli/bin/bina.json
-  build-linux-amd64:
-    name: Build Linux x86-64 binary
+  build:
+    name: Build and release
     runs-on: ubuntu-latest
     env:
-      GOVER: 1.19
+      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+
     steps:
-      - name: Set up Go ${{ env.GOVER }}
+      - name: Check out
+        uses: actions/checkout@v3
+
+      - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: ${{ env.GOVER }}
-      - name: Check out code
-        uses: actions/checkout@v3
-      - name: Run go mod tidy
-        run: go mod tidy
-      - name: build & archive binaries
-        run: cd ./cli && make archive-release-linux-amd64
-      - name: upload artifacts
-        uses: actions/upload-artifact@master
-        with:
-          name: yomo-artifact
-          path: ./cli/bin/**/*.tar.gz
-  build-linux-arm64:
-    name: Build Linux arm64 binary
-    runs-on: [self-hosted, Linux, ARM64]
-    env:
-      GOVER: 1.19
-    steps:
-      - name: Set up Go ${{ env.GOVER }}
-        uses: actions/setup-go@v4
-        with:
-          go-version: ${{ env.GOVER }}
-      - name: Check out code
-        uses: actions/checkout@v3
-      - name: Run go mod tidy
-        run: go mod tidy
-      - name: build & archive binaries
+          go-version: 1.19
+
+      - name: Run build script
+        env:
+          PLATFORMS: 'darwin/amd64,darwin/arm64,windows/amd64,windows/arm64,linux/amd64,linux/arm64,freebsd/amd64,freebsd/arm64'
         run: |
-          sudo apt-get update && sudo apt-get -y upgrade
-          sudo apt-get install -y make
-          sudo apt-get install -y gcc
-          cd ./cli && make archive-release-linux-arm64
-      - name: upload artifacts
-        uses: actions/upload-artifact@master
-        with:
-          name: yomo-artifact
-          path: ./cli/bin/**/*.tar.gz
-  build-darwin-amd64:
-    name: Build MacOS x86-64 binary
-    runs-on: macos-latest
-    env:
-      GOVER: 1.19
-    steps:
-      - name: Set up Go ${{ env.GOVER }}
-        uses: actions/setup-go@v4
-        with:
-          go-version: ${{ env.GOVER }}
-      - name: Check out code
-        uses: actions/checkout@v3
-      - name: Run go mod tidy
-        run: go mod tidy
-      - name: build & archive binaries
-        run: cd ./cli && make archive-release-darwin-amd64
-      - name: upload artifacts
-        uses: actions/upload-artifact@master
-        with:
-          name: yomo-artifact
-          path: ./cli/bin/**/*.tar.gz
-  build-windows-amd64:
-    name: Build Windows x86-64 binary
-    runs-on: windows-latest
-    env:
-      GOVER: 1.19
-    steps:
-      - name: Set up Go ${{ env.GOVER }}
-        uses: actions/setup-go@v4
-        with:
-          go-version: ${{ env.GOVER }}
-      - name: Check out code
-        uses: actions/checkout@v3
-      - name: Run go mod tidy
-        run: go mod tidy
-      - name: build & archive binaries
+          bash ./build.sh
+
+      - name: Generate hashes
         run: |
-          cd ./cli && make archive-release-windows-amd64
-      - name: upload artifacts
-        uses: actions/upload-artifact@master
-        with:
-          name: yomo-artifact
-          path: ./cli/bin/**/*.tar.gz
-  publish:
-    name: Publish binaries
-    needs: [bina-for-curl-download, build-linux-amd64, build-linux-arm64, build-darwin-amd64, build-windows-amd64]
-    env:
-      ARTIFACT_DIR: ./release
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v3
-      - name: download artifacts
-        uses: actions/download-artifact@master
-        with:
-          name: yomo-artifact
-          path: ${{ env.ARTIFACT_DIR }}
-      - name: lists artifacts
-        run: ls -l ${{ env.ARTIFACT_DIR }}
-      - name: build version
-        run: cd ./cli && make cli_version
-      - name: Get version
-        id: tag
-        run: echo "name=version::$(cat ./cli/VERSION)" >> $GITHUB_OUTPUT
-      - name: publish binaries to github
+          cd ./build
+          for f in $(find . -type f); do
+            sha256sum $f | sudo tee -a hashes.txt
+          done
+
+      - name: Upload
         uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
         with:
-          prerelease: true
-          tag_name: ${{ steps.tag.outputs.version }}
-          files: ${{ env.ARTIFACT_DIR }}/*
-      - name: Dispatch release notification
-        uses: peter-evans/repository-dispatch@v2
-        with:
-          token: ${{ secrets.YOMO_BOT_TOKEN }}
-          repository: yomorun/get.yomo.run
-          event-type: cli-released
-          client-payload: '{"version": "${{ steps.tag.outputs.version }}"}'
+          files: |
+            ./build/yomo-amd64-darwin.zip
+            ./build/yomo-arm64-darwin.zip
+            ./build/yomo-windows.zip
+            ./build/yomo-windows.zip
+            ./build/yomo-amd64-linux.zip
+            ./build/yomo-arm64-linux.zip
+            ./build/yomo-amd64-freebsd.zip
+            ./build/yomo-arm64-freebsd.zip
+            ./build/hashes.txt

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ Cargo.lock
 target
 coverage.txt
 *.o
+build/

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Environment variable options:
+#   - PLATFORMS: Platforms to build for (e.g. "windows/amd64,linux/amd64,darwin/amd64")
+
+export CLI_VERSION=$(shell git describe --tags 2>/dev/null || git rev-parse --short HEAD)
+
+export LC_ALL=C
+export LC_DATE=C
+
+make_ldflags() {
+    local ldflags="-s -w -X 'github.com/yomorun/yomo/cli.Version=$CLI_VERSION'"
+    echo "$ldflags"
+}
+
+build_for_platform() {
+    local platform="$1"
+    local ldflags="$2"
+
+    echo $platform
+    echo $ldflags
+
+    local GOOS="${platform%/*}"
+    local GOARCH="${platform#*/}"
+    if [[ -z "$GOOS" || -z "$GOARCH" ]]; then
+        echo "Invalid platform $platform" >&2
+        return 1
+    fi
+    echo "Building $GOOS/$GOARCH"
+    local output="build/yomo"
+    if [[ "$GOOS" = "windows" ]]; then
+        output="$output.exe"
+    fi
+    # compress to .zip file
+    local binfile="build/yomo-$GOARCH-$GOOS.zip"
+    local exit_val=0
+    GOOS=$GOOS GOARCH=$GOARCH go build -o "$output" -ldflags "$ldflags" -trimpath ./cmd/yomo/main.go || exit_val=$?
+    # compress compiled binary to .zip
+    zip -r -j "$binfile" "$output"
+    rm -rf $output
+    if [[ "$exit_val" -ne 0 ]]; then
+        echo "Error: failed to build $GOOS/$GOARCH" >&2
+        return $exit_val
+    fi
+}
+
+if [ -z "$PLATFORMS" ]; then
+    PLATFORMS="$(go env GOOS)/$(go env GOARCH)"
+fi
+
+platforms=(${PLATFORMS//,/ })
+ldflags="$(make_ldflags)"
+
+mkdir -p build
+rm -rf build/*
+
+echo "Starting build..."
+
+for platform in "${platforms[@]}"; do
+    build_for_platform "$platform" "$ldflags"
+done
+
+echo "Build complete."
+
+ls -lh build/ | awk '{print $9, $5}'


### PR DESCRIPTION
# Description

By #479, getting rid of problems in cross-compile. 

I update the Github Action release.yml to support this target builds automatically:

- darwin/amd64
- darwin/arm64
- windows/amd64
- windows/arm64
- linux/amd64
- linux/arm64
- freebsd/amd64
- freebsd/arm64