### PR TITLE
Chore: update build script, improve debug outputs

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -12,15 +12,11 @@ export LC_DATE=C
 
 make_ldflags() {
     local ldflags="-s -w -X 'github.com/yomorun/yomo/cli.Version=$CLI_VERSION'"
-    echo "$ldflags"
 }
 
 build_for_platform() {
     local platform="$1"
     local ldflags="$2"
-
-    echo $platform
-    echo $ldflags
 
     local GOOS="${platform%/*}"
     local GOARCH="${platform#*/}"


### PR DESCRIPTION
Also, fix these Codacy warnings:

<img width="645" alt="image" src="https://user-images.githubusercontent.com/65603/232325932-cd850527-05bf-4345-b49d-920bfb64744a.png">

P.S. can test `build.sh` by this command:

```bash
PLATFORMS=darwin/amd64,darwin/arm64,windows/amd64,windows/arm64,linux/amd64,linux/arm64,freebsd/amd64,freebsd/arm64 bash build.sh
```
