### PR TITLE
refactor: improve log with the stream type omit space

### DIFF
--- a/core/client_test.go
+++ b/core/client_test.go
@@ -3,7 +3,6 @@ package core
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"net"
 	"sync"
 	"testing"
@@ -201,11 +200,6 @@ func newFrameWriterRecorder() *frameWriterRecorder {
 func (w *frameWriterRecorder) WriteFrame(frm frame.Frame) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-
-	if frm.Type() == frame.TagOfDataFrame {
-		f := frm.(*frame.DataFrame)
-		fmt.Println("----------", f.GetMetaFrame().Metadata())
-	}
 
 	_, err := w.buf.Write(frm.Encode())
 	return err

--- a/core/data_stream.go
+++ b/core/data_stream.go
@@ -129,9 +129,9 @@ func (c StreamType) String() string {
 	case StreamTypeSource:
 		return "Source"
 	case StreamTypeUpstreamZipper:
-		return "Upstream Zipper"
+		return "UpstreamZipper"
 	case StreamTypeStreamFunction:
-		return "Stream Function"
+		return "StreamFunction"
 	default:
 		return "None"
 	}


### PR DESCRIPTION
# Description

Remove the space in the stream type. This will result in a log that appears as follows:

```
time=2023-04-19T12:01:16.433+08:00 level=INFO msg="use credential" component=StreamFunction client_id=CwIH4_0rpO_faPDJy6lUB client_name=Noise credential_name=none
```