### PR TITLE
feat: allow developers to create multiple source data streams

### DIFF
--- a/source.go
+++ b/source.go
@@ -25,6 +25,8 @@ type Source interface {
 	SetReceiveHandler(fn func(tag frame.Tag, data []byte))
 	// Write the data to all downstream
 	Broadcast(data []byte) error
+	// NewStream will create a new data stream [experimental feature]
+	NewStream(metadata []byte) (core.DataStream, error)
 }
 
 // YoMo-Source
@@ -114,4 +116,9 @@ func (s *yomoSource) Broadcast(data []byte) error {
 	f.SetBroadcast(true)
 	s.client.Logger().Debug("broadcast", "data_frame", f.String())
 	return s.client.WriteFrame(f)
+}
+
+// NewStream will create a new data stream [experimental feature]
+func (s *yomoSource) NewStream(metadata []byte) (core.DataStream, error) {
+	return s.client.NewStream(metadata)
 }


### PR DESCRIPTION
# Description

In order to avoid the head-of-line blocking problem, we want to provide developers the option to create multiple data streams in a single source QUIC connection. Streams are isolated from each other.

## Impact

This is a new experimental feature with no side effect on current platform.

# Test

todo
