### PR TITLE
fix: wazero runtime used real time clock

### DIFF
--- a/cli/serverless/wasm/wazero.go
+++ b/cli/serverless/wasm/wazero.go
@@ -35,7 +35,7 @@ func newWazeroRuntime() (*wazeroRuntime, error) {
 	// Instantiate WASI, which implements host functions needed for TinyGo to implement `panic`.
 	wasi_snapshot_preview1.MustInstantiate(ctx, r)
 	config := wazero.NewModuleConfig().
-		// WithStartFunctions().
+		WithSysWalltime().
 		WithStdin(os.Stdin).
 		WithStdout(os.Stdout).
 		WithStderr(os.Stderr)


### PR DESCRIPTION
# Description

WebAssembly has an implicit design pattern of capabilities based security. By defaulting to a fake time clock, configuration to real time clocks right now. [see more...](https://github.com/tetratelabs/wazero/blob/main/RATIONALE.md#syswalltime-and-nanotime)

