### PR TITLE
remove sfn write method

### DIFF
--- a/cli/serverless/deno/mod/mod.ts
+++ b/cli/serverless/deno/mod/mod.ts
@@ -107,6 +107,9 @@ export async function run(
 
     const ctx = new Context(tag, data, conn);
     await handler(ctx);
+
+    await conn.write(numberToBytes(0)); // tag
+    await conn.write(numberToBytes(0)); // length
   }
 
   conn.close();

--- a/sfn.go
+++ b/sfn.go
@@ -23,8 +23,6 @@ type StreamFunction interface {
 	Connect() error
 	// Close will close the connection
 	Close() error
-	// Send a data to zipper.
-	Write(tag uint32, carriage []byte) error
 }
 
 // NewStreamFunction create a stream function.
@@ -151,13 +149,6 @@ func (s *streamFunction) onDataFrame(dataFrame *frame.DataFrame) {
 	} else {
 		s.client.Logger().Warn("sfn does not have a handler")
 	}
-}
-
-// Send a DataFrame to zipper.
-func (s *streamFunction) Write(tag uint32, carriage []byte) error {
-	frame := frame.NewDataFrame()
-	frame.SetCarriage(tag, carriage)
-	return s.client.WriteFrame(frame)
 }
 
 // SetErrorHandler set the error handler function when server error occurs


### PR DESCRIPTION
# Description

Since the new SFN handler had been designed to be capable of sending data more than once, it's unnecessary to keep the `Write` method in StreamFunction interface.

## Impact

Deno applications will be affected, though only the mod.ts file.
