### PR TITLE
feat: wasm http supports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ vet:
 
 .PHONY: lint
 lint:
-	revive -exclude example/... -exclude cli/... -formatter friendly ./...
+	revive -exclude example/... -exclude cli/... -exclude vendor/... -formatter friendly ./...
 
 .PHONY: build
 build:

--- a/cli/serverless/wasm/http/http.go
+++ b/cli/serverless/wasm/http/http.go
@@ -1,0 +1,6 @@
+package http
+
+const (
+	// http
+	WasmFuncHTTPSend = "yomo_http_send"
+)

--- a/cli/serverless/wasm/wazero/http.go
+++ b/cli/serverless/wasm/wazero/http.go
@@ -1,0 +1,120 @@
+package wazero
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/tetratelabs/wazero"
+	"github.com/tetratelabs/wazero/api"
+	wasmhttp "github.com/yomorun/yomo/cli/serverless/wasm/http"
+	"github.com/yomorun/yomo/serverless"
+)
+
+const DefaultHTTPTimeout = 10 * time.Second
+
+type Request struct{}
+
+func ExportHTTPHostFuncs(builder wazero.HostModuleBuilder) {
+	builder.
+		// get
+		NewFunctionBuilder().
+		WithGoModuleFunction(
+			api.GoModuleFunc(Send),
+			[]api.ValueType{
+				api.ValueTypeI32, // reqPtr
+				api.ValueTypeI32, // reqSize
+				api.ValueTypeI32, // respPtr
+				api.ValueTypeI32, // respSize
+			},
+			[]api.ValueType{api.ValueTypeI32}, // ret
+		).
+		Export(wasmhttp.WasmFuncHTTPSend)
+}
+
+// Send sends a HTTP request and returns the response
+func Send(ctx context.Context, m api.Module, stack []uint64) {
+	// request
+	reqPtr := uint32(stack[0])
+	reqSize := uint32(stack[1])
+	reqBuf, err := readBuffer(ctx, m, reqPtr, reqSize)
+	if err != nil {
+		log.Printf("[HTTP] Send: get request error: %s\n", err)
+		stack[0] = 1
+		return
+	}
+	var req serverless.HTTPRequest
+	if err := json.Unmarshal(reqBuf, &req); err != nil {
+		log.Printf("[HTTP] Send: unmarshal request error: %s\n", err)
+		stack[0] = 2
+		return
+	}
+	// create http client
+	// 10 seconds timeout
+	timeout := DefaultHTTPTimeout
+	if req.Timeout > 0 {
+		timeout = time.Duration(req.Timeout * 1e6)
+	}
+
+	client := &http.Client{Timeout: timeout}
+	// create http request
+	reqBody := bytes.NewReader(req.Body)
+	request, err := http.NewRequest(req.Method, req.URL, reqBody)
+	if err != nil {
+		log.Printf("[HTTP] Send: create http request error: %s\n", err)
+		stack[0] = 3
+		return
+	}
+	// set headers
+	for k, v := range req.Header {
+		request.Header.Set(k, v)
+	}
+	// send http request
+	response, err := client.Do(request)
+	if err != nil {
+		log.Printf("[HTTP] Send: http request error: %s\n", err)
+		stack[0] = 4
+		return
+	}
+	defer response.Body.Close()
+	// response
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		log.Printf("[HTTP] Send: read response body error: %s\n", err)
+		stack[0] = 5
+		return
+	}
+	resp := serverless.HTTPResponse{
+		Status:     response.Status,
+		StatusCode: response.StatusCode,
+		Header:     make(map[string]string),
+		Body:       body,
+	}
+	// response headers
+	for k, v := range response.Header {
+		if len(v) > 0 {
+			resp.Header[k] = v[0]
+		}
+	}
+	// marshal response
+	respBuf, err := json.Marshal(resp)
+	if err != nil {
+		log.Printf("[HTTP] Send: marshal response error: %s\n", err)
+		stack[0] = 6
+		return
+	}
+	// write response
+	respPtr := uint32(stack[2])
+	respSize := uint32(stack[3])
+	if err := allocateBuffer(ctx, m, respPtr, respSize, respBuf); err != nil {
+		log.Printf("[HTTP] Send: write response error: %s\n", err)
+		stack[0] = 7
+		return
+	}
+	// return
+	stack[0] = 0
+}

--- a/cli/serverless/wasm/wazero/memory.go
+++ b/cli/serverless/wasm/wazero/memory.go
@@ -1,0 +1,44 @@
+package wazero
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/tetratelabs/wazero/api"
+)
+
+// allocateBuffer allocates memory and writes the data to the memory
+func allocateBuffer(
+	ctx context.Context,
+	m api.Module,
+	bufPtr uint32,
+	bufSize uint32,
+	buf []byte,
+) error {
+	bufLen := len(buf)
+	memResults, err := m.ExportedFunction("yomo_alloc").Call(ctx, uint64(bufLen))
+	if err != nil {
+		return err
+	}
+	allocPtr := uint32(memResults[0])
+	if !m.Memory().WriteUint32Le(bufPtr, allocPtr) {
+		return fmt.Errorf("memory write(%d) with %d out of range", bufPtr, allocPtr)
+	}
+	if !m.Memory().WriteUint32Le(bufSize, uint32(bufLen)) {
+		return fmt.Errorf("memory write(%d) with %d out of range", bufSize, bufLen)
+	}
+	if !m.Memory().Write(allocPtr, buf) {
+		return fmt.Errorf("memory write(%d, %d) out of range", allocPtr, bufLen)
+	}
+	return nil
+}
+
+func readBuffer(ctx context.Context, m api.Module, bufPtr uint32, bufSize uint32) ([]byte, error) {
+	buf, ok := m.Memory().Read(bufPtr, bufSize)
+	if !ok {
+		return nil, fmt.Errorf("memory read(%d, %d) out of range", bufPtr, bufSize)
+	}
+	result := make([]byte, bufSize)
+	copy(result, buf)
+	return result, nil
+}

--- a/core/serverless/context_http.go
+++ b/core/serverless/context_http.go
@@ -1,0 +1,10 @@
+package serverless
+
+import (
+	"github.com/yomorun/yomo/serverless"
+)
+
+// HTTP is the interface for HTTP request, but it is not implemented in the server side
+func (c *Context) HTTP() serverless.HTTP {
+	return nil
+}

--- a/example/7-wasm/sfn/go-http/README.md
+++ b/example/7-wasm/sfn/go-http/README.md
@@ -1,0 +1,16 @@
+# Go wasm serverless function
+
+## Install TinyGo
+
+The official Go compiler hasn't support WASI yet, therefore we need to use
+[TinyGo](https://tinygo.org) instead.
+
+https://tinygo.org/getting-started/install/
+
+## Build
+
+```sh
+tinygo build -o sfn.wasm -no-debug -target wasi
+
+cp sfn.wasm ../
+```

--- a/example/7-wasm/sfn/go-http/go.mod
+++ b/example/7-wasm/sfn/go-http/go.mod
@@ -1,0 +1,7 @@
+module app
+
+go 1.19
+
+replace github.com/yomorun/yomo => ../../../../
+
+require github.com/yomorun/yomo v0.0.0

--- a/example/7-wasm/sfn/go-http/sfn.go
+++ b/example/7-wasm/sfn/go-http/sfn.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/yomorun/yomo/serverless"
+	"github.com/yomorun/yomo/serverless/guest"
+)
+
+func main() {
+	guest.DataTags = DataTags
+	guest.Handler = Handler
+}
+
+func Handler(ctx serverless.Context) {
+	log.Println("[SFN] ------------------------- BEGIN -------------------------")
+	// load input data
+	tag := ctx.Tag()
+	input := ctx.Data()
+	fmt.Printf("[SFN] received %d bytes with tag[%#x]\n", len(input), tag)
+
+	// process app data
+	// output := strings.ToUpper(string(input))
+
+	// Get https://example.org
+	resp, err := ctx.HTTP().Get("https://example.org")
+	if err != nil {
+		fmt.Printf("[SFN] execute `HTTP().Get()` request error: %s\n", err)
+		return
+	}
+	log.Printf(
+		"[SFN] execute `HTTP().Get()` response result: content-type=%s, body=%s\n",
+		resp.Header["Content-Type"],
+		resp.Body,
+	)
+	// Post form post
+	host := "https://httpbin.org"
+	resp, err = ctx.HTTP().Post(
+		host+"/post",
+		"application/x-www-form-urlencoded",
+		[]byte(
+			"custname=customer&custtel=332323&custemail=foo%40bar.com&size=medium&topping=bacon&topping=cheese&delivery=11%3A45&comments=abcdefg",
+		),
+	)
+	if err != nil {
+		fmt.Printf("[SFN] execute `HTTP().Post()` request error: %s\n", err)
+		return
+	}
+	log.Printf(
+		"[SFN] execute `HTTP().Post()` response result: content-type=%s, body=%s\n",
+		resp.Header["Content-Type"],
+		resp.Body,
+	)
+	// httpbin.org test
+	req := &serverless.HTTPRequest{
+		Method:  "GET",
+		URL:     host + "/get",
+		Timeout: 3000, // 3s
+	}
+	// send http GET request
+	resp, err = ctx.HTTP().Send(req)
+	if err != nil {
+		fmt.Printf("[SFN] execute http GET request error: %s\n", err)
+		return
+	}
+	display(req, resp)
+	// send http GET request with header
+	req.Method = "GET"
+	req.URL = host + "/json"
+	req.Body = []byte("hello world")
+	req.Header = map[string]string{
+		"Content-Type": "application/json",
+	}
+	resp, err = ctx.HTTP().Send(req)
+	if err != nil {
+		fmt.Printf("[SFN] execute http GET request with header error: %s\n", err)
+		return
+	}
+	display(req, resp)
+	// send http GET request with query
+	req.Method = "GET"
+	req.URL = host + "/get?name=foo&age=10"
+	req.Body = []byte("hello world")
+	req.Header = map[string]string{
+		"Content-Type": "application/json",
+	}
+	resp, err = ctx.HTTP().Send(req)
+	if err != nil {
+		fmt.Printf("[SFN] execute http GET request with query error: %s\n", err)
+		return
+	}
+	display(req, resp)
+	// send http POST request
+	req.Method = "POST"
+	req.URL = host + "/post"
+	req.Body = []byte("hello world")
+	resp, err = ctx.HTTP().Send(req)
+	if err != nil {
+		fmt.Printf("[SFN] execute http POST request error: %s\n", err)
+		return
+	}
+	display(req, resp)
+	// send http PUT request
+	req.Method = "PUT"
+	req.URL = host + "/put"
+	req.Body = []byte("hello world")
+	resp, err = ctx.HTTP().Send(req)
+	if err != nil {
+		fmt.Printf("[SFN] execute http PUT request error: %s\n", err)
+		return
+	}
+	display(req, resp)
+	// send http DELETE request
+	req.Method = "DELETE"
+	req.URL = host + "/delete"
+	req.Body = []byte("hello world")
+	resp, err = ctx.HTTP().Send(req)
+	if err != nil {
+		fmt.Printf("[SFN] execute http DELETE request error: %s\n", err)
+		return
+	}
+	display(req, resp)
+	// send http PATCH request
+	req.Method = "PATCH"
+	req.URL = host + "/patch"
+	req.Body = []byte("hello world")
+	resp, err = ctx.HTTP().Send(req)
+	if err != nil {
+		fmt.Printf("[SFN] execute http PATCH request error: %s\n", err)
+		return
+	}
+	display(req, resp)
+	// dump output data
+	// ctx.Write(0x34, []byte(output))
+	log.Println("[SFN] -------------------------- END --------------------------")
+}
+
+func display(req *serverless.HTTPRequest, resp *serverless.HTTPResponse) {
+	log.Printf("[SFN] execute [%s]`%s` response result: status=%v, status_code=%d, header=%+v\n",
+		req.Method, req.URL,
+		resp.Status, resp.StatusCode, resp.Header,
+	)
+	log.Printf("\t\tbody: %s\n", string(resp.Body))
+}
+
+func DataTags() []uint32 {
+	return []uint32{0x33}
+}

--- a/serverless/context.go
+++ b/serverless/context.go
@@ -8,4 +8,30 @@ type Context interface {
 	Tag() uint32
 	// Write write data to zipper
 	Write(tag uint32, data []byte) error
+	// HTTP http interface
+	HTTP() HTTP
+}
+
+// HTTP http interface
+type HTTP interface {
+	Send(req *HTTPRequest) (*HTTPResponse, error)
+	Get(url string) (*HTTPResponse, error)
+	Post(url string, contentType string, body []byte) (*HTTPResponse, error)
+}
+
+// HTTPRequest http request
+type HTTPRequest struct {
+	Method  string            // GET, POST, PUT, DELETE, ...
+	URL     string            // https://example.org
+	Header  map[string]string // {"Content-Type": "application/json"}
+	Timeout int64             // timeout in milliseconds
+	Body    []byte            // request body
+}
+
+// HTTPResponse http response
+type HTTPResponse struct {
+	Status     string            // "200 OK"
+	StatusCode int               // 200, 404, ...
+	Header     map[string]string // {"Content-Type": "application/json"}
+	Body       []byte            // response body
 }

--- a/serverless/guest/context_http.go
+++ b/serverless/guest/context_http.go
@@ -57,7 +57,7 @@ func (g *GuestHTTP) send(req *serverless.HTTPRequest) (*serverless.HTTPResponse,
 	var respPtr *uint32
 	var respSize uint32
 	if errCode := httpSend(reqPtr, reqSize, &respPtr, &respSize); errCode != 0 {
-		err := fmt.Errorf("http request error: %d\n", errCode)
+		err := fmt.Errorf("http request error: %d", errCode)
 		log.Printf("[GuestHTTP] Send: %s\n", err)
 		return nil, err
 	}

--- a/serverless/guest/context_http.go
+++ b/serverless/guest/context_http.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log"
 
+	_ "unsafe"
+
 	"github.com/yomorun/yomo/serverless"
 )
 

--- a/serverless/guest/context_http.go
+++ b/serverless/guest/context_http.go
@@ -1,0 +1,79 @@
+package guest
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/yomorun/yomo/serverless"
+)
+
+func (c *GuestContext) HTTP() serverless.HTTP {
+	return &GuestHTTP{}
+}
+
+type GuestHTTP struct{}
+
+// Send send http request and return http response
+func (g *GuestHTTP) Send(req *serverless.HTTPRequest) (*serverless.HTTPResponse, error) {
+	return g.send(req)
+}
+
+// Get send http GET request and return http response
+func (g *GuestHTTP) Get(url string) (*serverless.HTTPResponse, error) {
+	req := &serverless.HTTPRequest{
+		Method: "GET",
+		URL:    url,
+	}
+	return g.send(req)
+}
+
+// Post send http POST request and return http response
+func (g *GuestHTTP) Post(
+	url string,
+	contentType string,
+	body []byte,
+) (*serverless.HTTPResponse, error) {
+	req := &serverless.HTTPRequest{
+		Method: "POST",
+		URL:    url,
+		Header: map[string]string{"Content-Type": contentType},
+		Body:   body,
+	}
+	return g.send(req)
+}
+
+func (g *GuestHTTP) send(req *serverless.HTTPRequest) (*serverless.HTTPResponse, error) {
+	// request
+	reqBuf, err := json.Marshal(req)
+	if err != nil {
+		log.Printf("[GuestHTTP] Send: marshal request error: %s\n", err)
+		return nil, err
+	}
+	reqPtr, reqSize := bufferToPtrSize(reqBuf)
+	// do http request
+	var respPtr *uint32
+	var respSize uint32
+	if errCode := httpSend(reqPtr, reqSize, &respPtr, &respSize); errCode != 0 {
+		err := fmt.Errorf("http request error: %d\n", errCode)
+		log.Printf("[GuestHTTP] Send: %s\n", err)
+		return nil, err
+	}
+	// response
+	respBuf := readBufferFromMemory(respPtr, respSize)
+	if len(respBuf) == 0 {
+		err := fmt.Errorf("http response is empty")
+		log.Printf("[GuestHTTP] Send: %s\n", err)
+		return nil, err
+	}
+	var resp serverless.HTTPResponse
+	if err := json.Unmarshal(respBuf, &resp); err != nil {
+		log.Printf("[GuestHTTP] Send: unmarshal response error: %s\n", err)
+		return nil, err
+	}
+	return &resp, nil
+}
+
+//export yomo_http_send
+//go:linkname httpSend
+func httpSend(reqPtr uintptr, reqSize uint32, respPtr **uint32, respSize *uint32) uint32

--- a/serverless/guest/memory.go
+++ b/serverless/guest/memory.go
@@ -32,3 +32,28 @@ func GetBytes(fn func(ptr uintptr, size uint32) (len uint32)) (result []byte) {
 	_ = fn(ptr, size)
 	return buf
 }
+
+// bufferPtrSize returns the memory position and size of the buffer
+func bufferToPtrSize(buff []byte) (uintptr, uint32) {
+	ptr := &buff[0]
+	unsafePtr := uintptr(unsafe.Pointer(ptr))
+	return unsafePtr, uint32(len(buff))
+}
+
+// readBufferFromMemory returns a buffer
+func readBufferFromMemory(bufferPosition *uint32, length uint32) []byte {
+	buf := make([]byte, length)
+	ptr := uintptr(unsafe.Pointer(bufferPosition))
+	for i := 0; i < int(length); i++ {
+		s := *(*int32)(unsafe.Pointer(ptr + uintptr(i)))
+		buf[i] = byte(s)
+	}
+	return buf
+}
+
+//export yomo_alloc
+func alloc(size uint32) uintptr {
+	buf := make([]byte, size)
+	ptr := &buf[0]
+	return uintptr(unsafe.Pointer(ptr))
+}


### PR DESCRIPTION
## Description

sfn handler supports http calls and is currently supported in the wazero runtime.




## Docs

### Interface
```go
type HTTP interface {
	Send(req *HTTPRequest) (*HTTPResponse, error)
	Get(url string) (*HTTPResponse, error)
	Post(url string, contentType string, body []byte) (*HTTPResponse, error)
}
```

### Usage
Now we can make http calls in the SFN Handler function.
```go
func Handler(ctx serverless.Context) {
  ...
  // http calls
  ...
}
```

#### Get

```go
resp, err := ctx.HTTP().Get("https://example.org")
if err != nil {
  fmt.Printf("[SFN] execute `HTTP().Get()` request error: %s\n", err)
  return
}
log.Printf(
  "[SFN] execute `HTTP().Get()` response result: content-type=%s, body=%s\n",
  resp.Header["Content-Type"],
  resp.Body,
)
```

#### Post
```go
resp, err = ctx.HTTP().Post(
  "https://httpbin.org/post",
  "application/x-www-form-urlencoded",
  []byte(
"custname=customer&custtel=332323&custemail=foo%40bar.com&size=medium&topping=bacon&topping=cheese&delivery=11%3A45&comments=abcdefg",
  ),
)
if err != nil {
  fmt.Printf("[SFN] execute `HTTP().Post()` request error: %s\n", err)
  return
}
log.Printf(
  "[SFN] execute `HTTP().Post()` response result: content-type=%s, body=%s\n",
  resp.Header["Content-Type"],
  resp.Body,
)
```

#### Send
```go
req := &serverless.HTTPRequest{
  Method:  "GET",
  URL:     "https://httpbin.org/get",
  Timeout: 3000, // 3s
}
// send http GET request
resp, err = ctx.HTTP().Send(req)
if err != nil {
  fmt.Printf("[SFN] execute http GET request error: %s\n", err)
  return
}
log.Printf(
  "[SFN] execute `HTTP().Send()` response result: content-type=%s, body=%s\n",
  resp.Header["Content-Type"],
  resp.Body,
)
```

