### PR TITLE
feat: cli trace

### DIFF
--- a/cli/serverless/golang/templates/main.tmpl
+++ b/cli/serverless/golang/templates/main.tmpl
@@ -37,11 +37,9 @@ func runSFN(name string, addr string, credential string) (closeFn func() error, 
 		yomo.WithTracerProvider(tp),
 	)
 	closeFn = sfn.Close
-  // set observe data tags
-  sfn.SetObserveDataTags(DataTags()...)
 
-  // set observe data tags
-  sfn.SetObserveDataTags(DataTags()...)
+	// set observe data tags
+	sfn.SetObserveDataTags(DataTags()...)
 
 	// set handler
 	sfn.SetHandler(Handler)
@@ -49,7 +47,7 @@ func runSFN(name string, addr string, credential string) (closeFn func() error, 
 	// set error handler
 	sfn.SetErrorHandler(func(err error) {
 		log.Printf("[sfn][%s] error handler: %T %v\n", addr, err, err)
-		})
+	})
 
 	// start
 	err = sfn.Connect()

--- a/cli/serverless/golang/templates/main.tmpl
+++ b/cli/serverless/golang/templates/main.tmpl
@@ -24,17 +24,24 @@ func main() {
 }
 
 func runSFN(name string, addr string, credential string) (closeFn func() error, err error) {
+	// trace
+	tp, shutdown, err := trace.NewTracerProviderWithJaeger("yomo-sfn")
+	if err == nil {
+		log.Println("[sfn] 🛰 trace enabled")
+	}
+	defer shutdown(context.Background())
 	sfn := yomo.NewStreamFunction(
-        name,
+    name,
 		addr,
 		yomo.WithCredential(credential),
+		yomo.WithTracerProvider(tp),
 	)
 	closeFn = sfn.Close
   // set observe data tags
   sfn.SetObserveDataTags(DataTags()...)
 
-  	// set observe data tags
-  	sfn.SetObserveDataTags(DataTags()...)
+  // set observe data tags
+  sfn.SetObserveDataTags(DataTags()...)
 
 	// set handler
 	sfn.SetHandler(Handler)
@@ -42,7 +49,7 @@ func runSFN(name string, addr string, credential string) (closeFn func() error, 
 	// set error handler
 	sfn.SetErrorHandler(func(err error) {
 		log.Printf("[sfn][%s] error handler: %T %v\n", addr, err, err)
-	})
+		})
 
 	// start
 	err = sfn.Connect()

--- a/cli/serverless/golang/templates/main_rx.tmpl
+++ b/cli/serverless/golang/templates/main_rx.tmpl
@@ -37,8 +37,6 @@ func runSFN(name string, addr string, credential string) (closeFn func() error, 
 		yomo.WithTracerProvider(tp),
 	)
 	closeFn = sfn.Close
-  // set observe data tags
-  sfn.SetObserveDataTags(DataTags()...)
 
 	// set observe data tags
 	sfn.SetObserveDataTags(DataTags()...)

--- a/cli/serverless/golang/templates/main_rx.tmpl
+++ b/cli/serverless/golang/templates/main_rx.tmpl
@@ -24,10 +24,17 @@ func main() {
 }
 
 func runSFN(name string, addr string, credential string) (closeFn func() error, err error) {
+	// trace
+	tp, shutdown, err := trace.NewTracerProviderWithJaeger("yomo-sfn")
+	if err == nil {
+		log.Println("[sfn] 🛰 trace enabled")
+	}
+	defer shutdown(context.Background())
 	sfn := yomo.NewStreamFunction(
 		name,
 		addr,
 		yomo.WithCredential(credential),
+		yomo.WithTracerProvider(tp),
 	)
 	closeFn = sfn.Close
   // set observe data tags

--- a/core/client_test.go
+++ b/core/client_test.go
@@ -131,7 +131,7 @@ func TestFrameRoundTrip(t *testing.T) {
 	exited = checkClientExited(sameNameSfn, time.Second)
 	assert.False(t, exited, "the new sfn stream should not exited")
 
-	mdBytes, _ := NewDefaultMetadata(source.clientID, true, "tid", "sid").Encode()
+	mdBytes, _ := NewDefaultMetadata(source.clientID, true, "tid", "sid", false).Encode()
 
 	err = sameNameSfn.WriteFrame(&frame.DataFrame{Tag: backflowTag, Metadata: mdBytes, Payload: backflow})
 	assert.NoError(t, err)
@@ -144,7 +144,7 @@ func TestFrameRoundTrip(t *testing.T) {
 	assert.ElementsMatch(t, nameList, []string{"source", "sfn-1"})
 
 	md := metadata.New(
-		NewDefaultMetadata(source.clientID, true, "tid", "sid"),
+		NewDefaultMetadata(source.clientID, true, "tid", "sid", false),
 		metadata.M{
 			"foo": "bar",
 		},

--- a/core/metadata.go
+++ b/core/metadata.go
@@ -7,19 +7,25 @@ const (
 	MetadataBroadcastKey = "yomo-broadcast"
 	MetadataTIDKey       = "yomo-tid"
 	MetadataSIDKey       = "yomo-sid"
+	MetaTraced           = "yomo-traced"
 )
 
 // NewDefaultMetadata returns a default metadata.
-func NewDefaultMetadata(sourceID string, broadcast bool, tid string, sid string) metadata.M {
+func NewDefaultMetadata(sourceID string, broadcast bool, tid string, sid string, traced bool) metadata.M {
 	broadcastString := "false"
 	if broadcast {
 		broadcastString = "true"
+	}
+	tracedString := "false"
+	if traced {
+		tracedString = "true"
 	}
 	return metadata.M{
 		MetadataSourceIDKey:  sourceID,
 		MetadataBroadcastKey: broadcastString,
 		MetadataTIDKey:       tid,
 		MetadataSIDKey:       sid,
+		MetaTraced:           tracedString,
 	}
 }
 
@@ -47,6 +53,12 @@ func GetSIDFromMetadata(m metadata.M) string {
 	return sid
 }
 
+// GetTracedFromMetadata gets traced from metadata.
+func GetTracedFromMetadata(m metadata.M) bool {
+	traced, _ := m.Get(MetaTraced)
+	return traced == "true"
+}
+
 // SetTIDToMetadata sets tid to metadata.
 func SetTIDToMetadata(m metadata.M, tid string) {
 	m.Set(MetadataTIDKey, tid)
@@ -55,4 +67,13 @@ func SetTIDToMetadata(m metadata.M, tid string) {
 // SetSIDToMetadata sets sid to metadata.
 func SetSIDToMetadata(m metadata.M, sid string) {
 	m.Set(MetadataSIDKey, sid)
+}
+
+// SetTracedToMetadata sets traced to metadata.
+func SetTracedToMetadata(m metadata.M, traced bool) {
+	tracedString := "false"
+	if traced {
+		tracedString = "true"
+	}
+	m.Set(MetaTraced, tracedString)
 }

--- a/core/metadata_test.go
+++ b/core/metadata_test.go
@@ -7,16 +7,20 @@ import (
 )
 
 func TestMetadata(t *testing.T) {
-	md := NewDefaultMetadata("source", true, "xxxxxxx", "sssssss")
+	md := NewDefaultMetadata("source", true, "xxxxxxx", "sssssss", true)
 
 	assert.Equal(t, "source", GetSourceIDFromMetadata(md))
 	assert.Equal(t, true, GetBroadcastFromMetadata(md))
 	assert.Equal(t, "xxxxxxx", GetTIDFromMetadata(md))
 	assert.Equal(t, "sssssss", GetSIDFromMetadata(md))
+	assert.Equal(t, true, GetTracedFromMetadata(md))
 
 	SetTIDToMetadata(md, "ccccccc")
 	assert.Equal(t, "ccccccc", GetTIDFromMetadata(md))
 
 	SetSIDToMetadata(md, "aaaaaaa")
 	assert.Equal(t, "aaaaaaa", GetSIDFromMetadata(md))
+
+	SetTracedToMetadata(md, false)
+	assert.Equal(t, false, GetTracedFromMetadata(md))
 }

--- a/example/9-cli/Taskfile.yaml
+++ b/example/9-cli/Taskfile.yaml
@@ -41,13 +41,13 @@ tasks:
       - "yomo build -m go.mod app.go"
     status:
       - test -f sfn/sfn.wasm
-    internal: true
 
   source:
     desc: run source
     deps: [source-build]
     env:
       YOMO_LOG_LEVEL: error
+      YOMO_TRACE_JAEGER_ENDPOINT: 'http://localhost:14268/api/traces'
     cmds:
       - "./bin/source{{exeExt}}"
 
@@ -67,3 +67,4 @@ tasks:
       - "yomo serve -c config.yaml"
     env:
       YOMO_LOG_LEVEL: error
+      YOMO_TRACE_JAEGER_ENDPOINT: 'http://localhost:14268/api/traces'

--- a/example/9-cli/sfn/.env
+++ b/example/9-cli/sfn/.env
@@ -1,1 +1,2 @@
 YOMO_SFN_NAME=Noise
+YOMO_TRACE_JAEGER_ENDPOINT=http://localhost:14268/api/traces

--- a/example/9-cli/source/go.mod
+++ b/example/9-cli/source/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/matoous/go-nanoid/v2 v2.0.0 // indirect
 	github.com/onsi/ginkgo/v2 v2.11.0 // indirect
 	github.com/quic-go/qtls-go1-20 v0.3.1 // indirect
-	github.com/quic-go/quic-go v0.37.3 // indirect
+	github.com/quic-go/quic-go v0.37.4 // indirect
 	github.com/vmihailenco/msgpack/v5 v5.3.5 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/yomorun/y3 v1.0.5 // indirect

--- a/example/9-cli/source/go.sum
+++ b/example/9-cli/source/go.sum
@@ -32,8 +32,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/quic-go/qtls-go1-20 v0.3.1 h1:O4BLOM3hwfVF3AcktIylQXyl7Yi2iBNVy5QsV+ySxbg=
 github.com/quic-go/qtls-go1-20 v0.3.1/go.mod h1:X9Nh97ZL80Z+bX/gUXMbipO6OxdiDi58b/fMC9mAL+k=
-github.com/quic-go/quic-go v0.37.3 h1:pkHH3xaMNUNAh6OtgEV/0K6Fz+YIJXhPzgd/ShiRDm4=
-github.com/quic-go/quic-go v0.37.3/go.mod h1:YsbH1r4mSHPJcLF4k4zruUkLBqctEMBDR6VPvcYjIsU=
+github.com/quic-go/quic-go v0.37.4 h1:ke8B73yMCWGq9MfrCCAw0Uzdm7GaViC3i39dsIdDlH4=
+github.com/quic-go/quic-go v0.37.4/go.mod h1:YsbH1r4mSHPJcLF4k4zruUkLBqctEMBDR6VPvcYjIsU=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/source.go
+++ b/source.go
@@ -99,6 +99,7 @@ func (s *yomoSource) write(tag uint32, data []byte, broadcast bool) error {
 	var tid, sid string
 	// trace
 	tp := s.client.TracerProvider()
+	traced := false
 	if tp != nil {
 		span, err := trace.NewSpan(tp, core.StreamTypeSource.String(), s.name, "", "")
 		if err != nil {
@@ -107,6 +108,7 @@ func (s *yomoSource) write(tag uint32, data []byte, broadcast bool) error {
 			defer span.End()
 			tid = span.SpanContext().TraceID().String()
 			sid = span.SpanContext().SpanID().String()
+			traced = true
 		}
 	}
 	if tid == "" {
@@ -117,11 +119,9 @@ func (s *yomoSource) write(tag uint32, data []byte, broadcast bool) error {
 		s.client.Logger().Debug("source create new sid")
 		sid = id.SID()
 	}
-	if tp != nil {
-		s.client.Logger().Debug("source trace", "tid", tid, "sid", sid, "broadcast", broadcast)
-	}
+	s.client.Logger().Debug("source metadata", "tid", tid, "sid", sid, "broadcast", broadcast, "traced", traced)
 	// metadata
-	md, err := core.NewDefaultMetadata(s.client.ClientID(), broadcast, tid, sid).Encode()
+	md, err := core.NewDefaultMetadata(s.client.ClientID(), broadcast, tid, sid, traced).Encode()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

Added the OpenTelemetry interface on CLI

## Usage
Use Jaeger as the tracer exporter，configure the value of environment a for your [Jaeger](https://www.jaegertracing.io/) endpoint:

```
YOMO_TRACE_JAEGER_ENDPOINT=http://localhost:14268/api/traces
```

## Run SFN

```bash
yomo run sfn.wasm
```

## Traces View

In the browser open jaeger UI (http://localhost:16686/search), select services, click the list items to view the SFN trace, more content, please view the example: [9-cli](https://github.com/yomorun/yomo/tree/master/example/9-cli)

<img width="736" alt="jaeger_ui_service" src="https://github.com/yomorun/yomo/assets/1587671/8c64d7bf-1c3f-40dc-a08b-051d7f71b2cb">

<img width="813" alt="jaeger_ui_view" src="https://github.com/yomorun/yomo/assets/1587671/a8203b6d-a34c-43ee-b36b-d907619873a0">
