### PR TITLE
feat: log metadata

### DIFF
--- a/core/metadata.go
+++ b/core/metadata.go
@@ -1,6 +1,9 @@
 package core
 
-import "github.com/yomorun/yomo/core/metadata"
+import (
+	"github.com/yomorun/yomo/core/metadata"
+	"golang.org/x/exp/slog"
+)
 
 const (
 	MetadataSourceIDKey  = "yomo-source-id"
@@ -76,4 +79,18 @@ func SetTracedToMetadata(m metadata.M, traced bool) {
 		tracedString = "true"
 	}
 	m.Set(MetaTraced, tracedString)
+}
+
+// MetadataSlogAttr returns slog.Attr from metadata.
+func MetadataSlogAttr(md metadata.M) slog.Attr {
+	kvStrings := make([]any, len(md)*2)
+	i := 0
+	for k, v := range md {
+		kvStrings[i] = k
+		i++
+		kvStrings[i] = v
+		i++
+	}
+
+	return slog.Group("metadata", kvStrings...)
 }

--- a/core/metadata_test.go
+++ b/core/metadata_test.go
@@ -1,9 +1,12 @@
 package core
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/yomorun/yomo/core/metadata"
+	"golang.org/x/exp/slog"
 )
 
 func TestMetadata(t *testing.T) {
@@ -23,4 +26,29 @@ func TestMetadata(t *testing.T) {
 
 	SetTracedToMetadata(md, false)
 	assert.Equal(t, false, GetTracedFromMetadata(md))
+}
+
+func TestMetadataSlogAttr(t *testing.T) {
+	md := metadata.New(map[string]string{
+		"aaaa": "bbbb",
+		"cccc": "dddd",
+	})
+
+	buf := bytes.NewBuffer(nil)
+
+	logger := slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{
+		AddSource: false,
+		Level:     slog.LevelDebug,
+		// display time attr.
+		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+			if a.Key == "time" {
+				return slog.Attr{}
+			}
+			return a
+		},
+	}))
+
+	logger.Debug("test metadata", MetadataSlogAttr(md))
+
+	assert.Equal(t, "level=DEBUG msg=\"test metadata\" metadata.aaaa=bbbb metadata.cccc=dddd\n", buf.String())
 }


### PR DESCRIPTION
# Description

log metadata, json format log content like this:

```json
{
    "time":"2023-08-24T16:37:21.100507+08:00",
    "level":"INFO",
    "msg":"routing data frame",
    "component":"zipper",
    "zipper_name":"Service",
    "zipper_addr":"localhost:9000",
    "remote_addr":"127.0.0.1:61155",
    "local_addr":"127.0.0.1:9000",
    "stream_id":"xt1hWdPb2Mn_qukKbiEGm",
    "stream_name":"yomo-source",
    "stream_type":"Source",
    "metadata":{
        "yomo-source-id":"xt1hWdPb2Mn_qukKbiEGm",
        "yomo-broadcast":"false",
        "yomo-tid":"0ead9de8693f62218ed0e7cdaf2c855a",
        "yomo-sid":"35ebcd627e508e68",
        "yomo-traced":"false"
    },
    "from_stream_name":"yomo-source",
    "from_stream_id":"xt1hWdPb2Mn_qukKbiEGm",
    "to_stream_name":"Noise",
    "to_stream_id":"_0YWmnUOJAmVk-GrfAi3G"
}
```
