### PR TITLE
feat(sfn): add wait api

### DIFF
--- a/example/0-basic/sfn/main.go
+++ b/example/0-basic/sfn/main.go
@@ -38,11 +38,9 @@ func main() {
 	// set the error handler function when server error occurs
 	sfn.SetErrorHandler(func(err error) {
 		slog.Error("[sfn] receive server error", "err", err)
-		sfn.Close()
-		os.Exit(1)
 	})
 
-	select {}
+	sfn.Wait()
 }
 
 func handler(ctx serverless.Context) {

--- a/example/3-multi-sfn/stream-fn-1/app.go
+++ b/example/3-multi-sfn/stream-fn-1/app.go
@@ -47,7 +47,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	select {}
+	sfn.Wait()
 }
 
 func handler(ctx serverless.Context) {

--- a/example/3-multi-sfn/stream-fn-2/app.go
+++ b/example/3-multi-sfn/stream-fn-2/app.go
@@ -54,7 +54,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	select {}
+	sfn.Wait()
 }
 
 func handler(ctx serverless.Context) {

--- a/example/3-multi-sfn/stream-fn-3/app.go
+++ b/example/3-multi-sfn/stream-fn-3/app.go
@@ -68,7 +68,7 @@ func main() {
 
 	go SlidingWindowWithTime(observe, SlidingWindowInMS, SlidingTimeInMS, slidingAvg)
 
-	select {}
+	sfn.Wait()
 }
 
 func handler(ctx serverless.Context) {

--- a/example/3-multi-sfn/stream-fn-4/app.go
+++ b/example/3-multi-sfn/stream-fn-4/app.go
@@ -34,7 +34,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	select {}
+	sfn.Wait()
 }
 
 func handler(ctx serverless.Context) {

--- a/example/4-cascading-zipper/sfn/sfn_echo.go
+++ b/example/4-cascading-zipper/sfn/sfn_echo.go
@@ -27,7 +27,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	select {}
+	sfn.Wait()
 }
 
 func handler(ctx serverless.Context) {

--- a/example/5-backflow/sfn-1/main.go
+++ b/example/5-backflow/sfn-1/main.go
@@ -42,7 +42,7 @@ func main() {
 		os.Exit(1)
 	})
 
-	select {}
+	sfn.Wait()
 }
 
 func handler(ctx serverless.Context) {

--- a/example/5-backflow/sfn-2/main.go
+++ b/example/5-backflow/sfn-2/main.go
@@ -36,7 +36,7 @@ func main() {
 		os.Exit(1)
 	})
 
-	select {}
+	sfn.Wait()
 }
 
 func handler(ctx serverless.Context) {

--- a/example/6-mesh/stream-fn-db/app.go
+++ b/example/6-mesh/stream-fn-db/app.go
@@ -58,7 +58,7 @@ func main() {
 		return
 	}
 
-	select {}
+	sfn.Wait()
 }
 
 func getPort() int {

--- a/example/6-mesh/stream-fn/app.go
+++ b/example/6-mesh/stream-fn/app.go
@@ -76,7 +76,7 @@ func main() {
 	// pipe rx stream and rx handler.
 	rt.Pipe(Handler)
 
-	select {}
+	sfn.Wait()
 }
 
 // DataTags observe tag list

--- a/sfn.go
+++ b/sfn.go
@@ -16,6 +16,8 @@ import (
 type StreamFunction interface {
 	// SetObserveDataTags set the data tag list that will be observed
 	SetObserveDataTags(tag ...uint32)
+	// Init will initialize the stream function
+	Init(fn func() error) error
 	// SetHandler set the handler function, which accept the raw bytes data and return the tag & response
 	SetHandler(fn core.AsyncHandler) error
 	// SetErrorHandler set the error handler function when server error occurs
@@ -26,8 +28,8 @@ type StreamFunction interface {
 	Connect() error
 	// Close will close the connection
 	Close() error
-	// Init will initialize the stream function
-	Init(fn func() error) error
+	// Wait waits sfn to finish.
+	Wait()
 }
 
 // NewStreamFunction create a stream function.
@@ -189,6 +191,11 @@ func (s *streamFunction) Close() error {
 	}
 
 	return nil
+}
+
+// Wait waits sfn to finish.
+func (s *streamFunction) Wait() {
+	s.client.Wait()
 }
 
 // when DataFrame we observed arrived, invoke the user's function


### PR DESCRIPTION
# Description

Adding `Wait()` API for `StreamFunction`, which is used to block the main function until the `StreamFunction` is closed either by the remote or the local.