### PR TITLE
feat: transmitting data is broadcast across zippers by default

### DIFF
--- a/core/client_test.go
+++ b/core/client_test.go
@@ -131,7 +131,7 @@ func TestFrameRoundTrip(t *testing.T) {
 	exited = checkClientExited(sameNameSfn, time.Second)
 	assert.False(t, exited, "the new sfn stream should not exited")
 
-	mdBytes, _ := NewDefaultMetadata(source.clientID, true, "tid", "sid", false).Encode()
+	mdBytes, _ := NewDefaultMetadata(source.clientID, "tid", "sid", false).Encode()
 
 	err = sameNameSfn.WriteFrame(&frame.DataFrame{Tag: backflowTag, Metadata: mdBytes, Payload: backflow})
 	assert.NoError(t, err)
@@ -144,7 +144,7 @@ func TestFrameRoundTrip(t *testing.T) {
 	assert.ElementsMatch(t, nameList, []string{"source", "sfn-1"})
 
 	md := metadata.New(
-		NewDefaultMetadata(source.clientID, true, "tid", "sid", false),
+		NewDefaultMetadata(source.clientID, "tid", "sid", false),
 		metadata.M{
 			"foo": "bar",
 		},

--- a/core/metadata.go
+++ b/core/metadata.go
@@ -6,29 +6,23 @@ import (
 )
 
 const (
-	MetadataSourceIDKey  = "yomo-source-id"
-	MetadataBroadcastKey = "yomo-broadcast"
-	MetadataTIDKey       = "yomo-tid"
-	MetadataSIDKey       = "yomo-sid"
-	MetaTraced           = "yomo-traced"
+	MetadataSourceIDKey = "yomo-source-id"
+	MetadataTIDKey      = "yomo-tid"
+	MetadataSIDKey      = "yomo-sid"
+	MetaTraced          = "yomo-traced"
 )
 
 // NewDefaultMetadata returns a default metadata.
-func NewDefaultMetadata(sourceID string, broadcast bool, tid string, sid string, traced bool) metadata.M {
-	broadcastString := "false"
-	if broadcast {
-		broadcastString = "true"
-	}
+func NewDefaultMetadata(sourceID string, tid string, sid string, traced bool) metadata.M {
 	tracedString := "false"
 	if traced {
 		tracedString = "true"
 	}
 	return metadata.M{
-		MetadataSourceIDKey:  sourceID,
-		MetadataBroadcastKey: broadcastString,
-		MetadataTIDKey:       tid,
-		MetadataSIDKey:       sid,
-		MetaTraced:           tracedString,
+		MetadataSourceIDKey: sourceID,
+		MetadataTIDKey:      tid,
+		MetadataSIDKey:      sid,
+		MetaTraced:          tracedString,
 	}
 }
 
@@ -36,12 +30,6 @@ func NewDefaultMetadata(sourceID string, broadcast bool, tid string, sid string,
 func GetSourceIDFromMetadata(m metadata.M) string {
 	sourceID, _ := m.Get(MetadataSourceIDKey)
 	return sourceID
-}
-
-// GetBroadcastFromMetadata gets broadcast from metadata.
-func GetBroadcastFromMetadata(m metadata.M) bool {
-	broadcast, _ := m.Get(MetadataBroadcastKey)
-	return broadcast == "true"
 }
 
 // GetTIDFromMetadata gets TID from metadata.

--- a/core/metadata_test.go
+++ b/core/metadata_test.go
@@ -10,10 +10,9 @@ import (
 )
 
 func TestMetadata(t *testing.T) {
-	md := NewDefaultMetadata("source", true, "xxxxxxx", "sssssss", true)
+	md := NewDefaultMetadata("source", "xxxxxxx", "sssssss", true)
 
 	assert.Equal(t, "source", GetSourceIDFromMetadata(md))
-	assert.Equal(t, true, GetBroadcastFromMetadata(md))
 	assert.Equal(t, "xxxxxxx", GetTIDFromMetadata(md))
 	assert.Equal(t, "sssssss", GetSIDFromMetadata(md))
 	assert.Equal(t, true, GetTracedFromMetadata(md))

--- a/core/server.go
+++ b/core/server.go
@@ -482,22 +482,19 @@ func (s *Server) AddDownstreamServer(addr string, c FrameWriterConnection) {
 func (s *Server) dispatchToDownstreams(c *Context) {
 	if c.DataStream.StreamType() == StreamTypeSource {
 		var (
-			broadcast = GetBroadcastFromMetadata(c.FrameMetadata)
-			tid       = GetTIDFromMetadata(c.FrameMetadata)
-			sid       = GetSIDFromMetadata(c.FrameMetadata)
+			tid = GetTIDFromMetadata(c.FrameMetadata)
+			sid = GetSIDFromMetadata(c.FrameMetadata)
 		)
-		if broadcast {
-			mdBytes, err := c.FrameMetadata.Encode()
-			if err != nil {
-				c.Logger.Error("failed to dispatch to downstream", "err", err)
-				return
-			}
-			c.Frame.Metadata = mdBytes
+		mdBytes, err := c.FrameMetadata.Encode()
+		if err != nil {
+			c.Logger.Error("failed to dispatch to downstream", "err", err)
+			return
+		}
+		c.Frame.Metadata = mdBytes
 
-			for streamID, ds := range s.downstreams {
-				c.Logger.Info("dispatching to downstream", "dispatch_stream_id", streamID, "tid", tid, "sid", sid)
-				ds.WriteFrame(c.Frame)
-			}
+		for streamID, ds := range s.downstreams {
+			c.Logger.Info("dispatching to downstream", "dispatch_stream_id", streamID, "tid", tid, "sid", sid)
+			ds.WriteFrame(c.Frame)
 		}
 	}
 }

--- a/docs/pages/docs/api/source.mdx
+++ b/docs/pages/docs/api/source.mdx
@@ -47,13 +47,6 @@ The default transactionID is epoch time.
 - `tag`: The [Tag][tag] of data.
 - `data`: The data to write.
 
-### source.Broadcast(tag uint32, data []byte) error
-
-Write the data to all downstreams with specified [Tag][tag].
-
-- `tag`: The [Tag][tag] of data.
-- `data`: The data to broadcast to all downstream [Zippers][zipper].
-
 ### source.SetErrorHandler(fn func(err error))
 
 Set the error handler function when server error occurs.

--- a/example/4-cascading-zipper/README.md
+++ b/example/4-cascading-zipper/README.md
@@ -5,7 +5,7 @@ This example represents how YoMo works with cascading zippers in mesh network.
 ## Code structure
 
 - `source`: Mocking random data and send it to `zipper-1`. [docs.yomo.run/source](https://yomo.run/docs/api/source)
-- `zipper-1`: Receive the streams from `source`, and broadcast it to downstream `zipper-2` in another region. [docs.yomo.run/zipper](https://yomo.run/docs/cli/zipper)
+- `zipper-1`: Receive the streams from `source`, and write it to downstream `zipper-2` in another region. [docs.yomo.run/zipper](https://yomo.run/docs/cli/zipper)
 - `zipper-2`: Receive the streams from upstream `zipper-1`. [docs.yomo.run/zipper](https://yomo.run/docs/cli/zipper)
 - `sfn`: Receive the streams from `zipper-2` and print it in terminal. [docs.yomo.run/stream-function](https://yomo.run/docs/api/sfn)
 

--- a/example/4-cascading-zipper/source/source.go
+++ b/example/4-cascading-zipper/source/source.go
@@ -38,8 +38,7 @@ func generateAndSendData(stream yomo.Source) error {
 		rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
 		data := []byte(fmt.Sprintf("%d", rnd.Uint32()))
 		// send data via QUIC stream.
-		// broadcast this message to cascading zippers using `Broadcast` method
-		err := stream.Broadcast(0x33, data)
+		err := stream.Write(0x33, data)
 		if err != nil {
 			log.Printf("[source] ❌ Emit %v to YoMo-Zipper failure with err: %v", data, err)
 			time.Sleep(500 * time.Millisecond)

--- a/example/6-mesh/source/main.go
+++ b/example/6-mesh/source/main.go
@@ -47,8 +47,8 @@ func generateAndSendData(stream yomo.Source) {
 		// Encode data via Y3 codec https://github.com/yomorun/y3-codec.
 		sendingBuf, _ := json.Marshal(data)
 
-		// broadcast this message to cascading zippers using `Broadcast` method
-		err := stream.Broadcast(0x10, sendingBuf)
+		// write this message to zippers
+		err := stream.Write(0x10, sendingBuf)
 		if err != nil {
 			log.Printf("❌ Emit %v to YoMo-Zipper failure with err: %v", data, err)
 		} else {

--- a/example/9-cli/source/main.go
+++ b/example/9-cli/source/main.go
@@ -75,10 +75,6 @@ func generateAndSendData(stream yomo.Source) error {
 
 		// send data via QUIC stream.
 		err := stream.Write(0x33, sendingBuf)
-		// using the following code, zipper will broadcast this message to cascading zippers.
-		// make sure to configure the downstream zippers using mesh-config flag,
-		// see the mesh example for more details.
-		// err := stream.Broadcast(0x33, sendingBuf)
 		if err != nil {
 			log.Printf("[source] ❌ Emit %v to YoMo-Zipper failure with err: %v", data, err)
 		} else {

--- a/example/README.md
+++ b/example/README.md
@@ -49,7 +49,7 @@ can run each example directly by `task example-basic`, `task example-cascading-z
 
 ## Cascading zippers
 
-- [4-cascading-zipper](https://github.com/yomorun/yomo/tree/master/example/4-cascading-zipper): [source](https://yomo.run/docs/api/source) connect to [zipper-1](https://yomo.run/docs/cli/zipper), then [zipper-1](https://yomo.run/docs/cli/zipper) will broadcast the streams to the zippers in other regions.
+- [4-cascading-zipper](https://github.com/yomorun/yomo/tree/master/example/4-cascading-zipper): [source](https://yomo.run/docs/api/source) connect to [zipper-1](https://yomo.run/docs/cli/zipper), then [zipper-1](https://yomo.run/docs/cli/zipper) will write the streams to the zippers in other regions.
 
 ## Backflow 
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -22,7 +22,7 @@ func TestParseConfigFile(t *testing.T) {
 
 		assert.Equal(t, "zipper-chn", conf.Name)
 		assert.Equal(t, "0.0.0.0", conf.Host)
-		assert.Equal(t, []Function{{Name: "sfn-ai-stream-response"}, {Name: "sfn-async-log-events"}}, conf.Functions)
+		assert.Equal(t, []Function{{Name: "sfn-ai-stream-response"}, {Name: "sfn-async-log-events"}, {Name: "sfn-test"}}, conf.Functions)
 
 		assert.Equal(t, 9000, conf.Port)
 	})

--- a/source_test.go
+++ b/source_test.go
@@ -8,11 +8,13 @@ import (
 	"github.com/yomorun/yomo/core"
 	"github.com/yomorun/yomo/core/frame"
 	"github.com/yomorun/yomo/core/ylog"
+	"github.com/yomorun/yomo/serverless"
 )
 
 func TestSource(t *testing.T) {
 	t.Parallel()
 
+	// source
 	source := NewSource(
 		"test-source",
 		"localhost:9000",
@@ -29,23 +31,34 @@ func TestSource(t *testing.T) {
 		close(exit)
 	})
 
+	// error handler
 	source.SetErrorHandler(func(err error) {})
 
+	// receiver handler
 	source.SetReceiveHandler(func(tag frame.Tag, data []byte) {
 		assert.Equal(t, uint32(0x22), tag)
 		assert.Equal(t, []byte("backflow"), data)
 	})
 
-	// connect to zipper
-	err := source.Connect()
+	// sfn
+	sfn := NewStreamFunction(
+		"sfn-test",
+		"localhost:9000",
+		WithSfnCredential("token:<CREDENTIAL>"),
+	)
+	sfn.SetObserveDataTags(0x21)
+	sfn.SetHandler(func(ctx serverless.Context) {
+		assert.Equal(t, []byte("test"), ctx.Data())
+	})
+	err := sfn.Connect()
 	assert.Nil(t, err)
 
-	// send data to zipper
+	// connect to zipper from source
+	err = source.Connect()
+	assert.Nil(t, err)
+
+	// send data to zipper from source
 	err = source.Write(0x21, []byte("test"))
-	assert.Nil(t, err)
-
-	// broadcast data to zipper
-	err = source.Broadcast(0x21, []byte("test"))
 	assert.Nil(t, err)
 
 	<-exit

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -12,6 +12,7 @@ auth:
 functions:
   - name: sfn-ai-stream-response
   - name: sfn-async-log-events
+  - name: sfn-test
 
 ### cascading ###
 downstreams:


### PR DESCRIPTION
# Description

Remove the source `Broadcast` method and the `Write` method sends data as a broadcast.

## Impact

~~Broadcast(tag uint32, data []byte) error~~

