### PR TITLE
loop protection in zipper mesh

### DIFF
--- a/core/server.go
+++ b/core/server.go
@@ -480,22 +480,25 @@ func (s *Server) AddDownstreamServer(addr string, c FrameWriterConnection) {
 
 // dispatch every DataFrames to all downstreams
 func (s *Server) dispatchToDownstreams(c *Context) {
-	if c.DataStream.StreamType() == StreamTypeSource {
-		var (
-			tid = GetTIDFromMetadata(c.FrameMetadata)
-			sid = GetSIDFromMetadata(c.FrameMetadata)
-		)
-		mdBytes, err := c.FrameMetadata.Encode()
-		if err != nil {
-			c.Logger.Error("failed to dispatch to downstream", "err", err)
-			return
-		}
-		c.Frame.Metadata = mdBytes
+	if c.DataStream.StreamType() == StreamTypeUpstreamZipper {
+		// loop protection
+		return
+	}
 
-		for streamID, ds := range s.downstreams {
-			c.Logger.Info("dispatching to downstream", "dispatch_stream_id", streamID, "tid", tid, "sid", sid)
-			ds.WriteFrame(c.Frame)
-		}
+	var (
+		tid = GetTIDFromMetadata(c.FrameMetadata)
+		sid = GetSIDFromMetadata(c.FrameMetadata)
+	)
+	mdBytes, err := c.FrameMetadata.Encode()
+	if err != nil {
+		c.Logger.Error("failed to dispatch to downstream", "err", err)
+		return
+	}
+	c.Frame.Metadata = mdBytes
+
+	for streamID, ds := range s.downstreams {
+		c.Logger.Info("dispatching to downstream", "dispatch_stream_id", streamID, "tid", tid, "sid", sid)
+		ds.WriteFrame(c.Frame)
 	}
 }
 


### PR DESCRIPTION
# Description

By the pr #612  all data frames will be forwarded to downstream zippers. Therefore the loop protection is necessary for zipper mesh scenario: avoid a data frame being processed by a unique SFN multiple times. 
