### PR TITLE
refactor: client type

### DIFF
--- a/core/client_options.go
+++ b/core/client_options.go
@@ -111,17 +111,3 @@ func WithTracerProvider(tp trace.TracerProvider) ClientOption {
 		o.tracerProvider = tp
 	}
 }
-
-// ClientType is equal to StreamType.
-type ClientType = StreamType
-
-const (
-	// ClientTypeSource is equal to StreamTypeSource.
-	ClientTypeSource ClientType = StreamTypeSource
-
-	// ClientTypeUpstreamZipper is equal to StreamTypeUpstreamZipper.
-	ClientTypeUpstreamZipper ClientType = StreamTypeUpstreamZipper
-
-	// ClientTypeStreamFunction is equal to StreamTypeStreamFunction.
-	ClientTypeStreamFunction ClientType = StreamTypeStreamFunction
-)

--- a/core/client_test.go
+++ b/core/client_test.go
@@ -27,7 +27,7 @@ var discardingLogger = ylog.NewFromConfig(ylog.Config{Output: "/dev/null", Error
 func TestClientDialNothing(t *testing.T) {
 	ctx := context.Background()
 
-	client := NewClient("source", StreamTypeSource, WithLogger(discardingLogger))
+	client := NewClient("source", ClientTypeSource, WithLogger(discardingLogger))
 	err := client.Connect(ctx, testaddr)
 
 	qerr := net.ErrClosed
@@ -67,13 +67,13 @@ func TestFrameRoundTrip(t *testing.T) {
 		server.ListenAndServe(ctx, testaddr)
 	}()
 
-	illegalTokenSource := NewClient("source", StreamTypeSource, WithCredential("token:error-token"), WithLogger(discardingLogger))
+	illegalTokenSource := NewClient("source", ClientTypeSource, WithCredential("token:error-token"), WithLogger(discardingLogger))
 	err := illegalTokenSource.Connect(ctx, testaddr)
 	assert.Equal(t, "authentication failed: client credential name is token", err.Error())
 
 	source := NewClient(
 		"source",
-		StreamTypeSource,
+		ClientTypeSource,
 		WithCredential("token:auth-token"),
 		WithClientQuicConfig(DefalutQuicConfig),
 		WithClientTLSConfig(nil),
@@ -216,7 +216,7 @@ func (a *hookTester) afterHandler(ctx *Context) error {
 func createTestStreamFunction(name string, observedTag frame.Tag) *Client {
 	sfn := NewClient(
 		name,
-		StreamTypeStreamFunction,
+		ClientTypeStreamFunction,
 		WithCredential("token:auth-token"),
 		WithLogger(discardingLogger),
 	)

--- a/core/client_type.go
+++ b/core/client_type.go
@@ -1,0 +1,34 @@
+package core
+
+// ClientType is the type of client.
+type ClientType byte
+
+const (
+	// ClientTypeSource is client type "Source".
+	// "Source" type client sends data to "Stream Function" stream generally.
+	ClientTypeSource ClientType = 0x5F
+
+	// ClientTypeUpstreamZipper is client type "Upstream Zipper".
+	// "Upstream Zipper" type client sends data from "Source" to other zipper node.
+	// With "Upstream Zipper", the yomo can run in mesh mode.
+	ClientTypeUpstreamZipper ClientType = 0x5E
+
+	// ClientTypeStreamFunction is client type "Stream Function".
+	// "Stream Function" handles data from source.
+	ClientTypeStreamFunction ClientType = 0x5D
+)
+
+var clientTypeStringMap = map[ClientType]string{
+	ClientTypeSource:         "Source",
+	ClientTypeUpstreamZipper: "UpstreamZipper",
+	ClientTypeStreamFunction: "StreamFunction",
+}
+
+// String returns string for StreamType.
+func (c ClientType) String() string {
+	str, ok := clientTypeStringMap[c]
+	if !ok {
+		return "Unknown"
+	}
+	return str
+}

--- a/core/client_type.go
+++ b/core/client_type.go
@@ -24,7 +24,7 @@ var clientTypeStringMap = map[ClientType]string{
 	ClientTypeStreamFunction: "StreamFunction",
 }
 
-// String returns string for StreamType.
+// String returns string for ClientType.
 func (c ClientType) String() string {
 	str, ok := clientTypeStringMap[c]
 	if !ok {

--- a/core/connector_test.go
+++ b/core/connector_test.go
@@ -118,5 +118,5 @@ func TestConnector(t *testing.T) {
 // mockDataStream returns a data stream that only includes an ID and a name.
 // This function is used for unit testing purposes.
 func mockDataStream(id, name string) DataStream {
-	return newDataStream(name, id, StreamType(0), nil, []frame.Tag{0}, nil, nil, nil)
+	return newDataStream(name, id, ClientType(0), nil, []frame.Tag{0}, nil, nil, nil)
 }

--- a/core/context.go
+++ b/core/context.go
@@ -100,7 +100,7 @@ func newContext(dataStream DataStream, route router.Route, logger *slog.Logger) 
 	logger = logger.With(
 		"stream_id", dataStream.ID(),
 		"stream_name", dataStream.Name(),
-		"stream_type", dataStream.StreamType().String(),
+		"stream_type", dataStream.ClientType().String(),
 	)
 
 	c.DataStream = dataStream

--- a/core/context.go
+++ b/core/context.go
@@ -100,7 +100,7 @@ func newContext(dataStream DataStream, route router.Route, logger *slog.Logger) 
 	logger = logger.With(
 		"stream_id", dataStream.ID(),
 		"stream_name", dataStream.Name(),
-		"stream_type", dataStream.ClientType().String(),
+		"client_type", dataStream.ClientType().String(),
 	)
 
 	c.DataStream = dataStream

--- a/core/control_stream.go
+++ b/core/control_stream.go
@@ -129,7 +129,7 @@ func (ss *ServerControlStream) OpenStream(ctx context.Context, handshakeFunc Han
 	dataStream := newDataStream(
 		ff.Name,
 		ff.ID,
-		StreamType(ff.StreamType),
+		ClientType(ff.ClientType),
 		md,
 		ff.ObserveDataTags,
 		NewFrameStream(stream, ss.codec, ss.packetReadWriter),
@@ -214,7 +214,6 @@ func OpenClientControlStream(
 	codec frame.Codec, packetReadWriter frame.PacketReadWriter,
 	logger *slog.Logger,
 ) (*ClientControlStream, error) {
-
 	conn, err := quic.DialAddr(ctx, addr, tlsConfig, quicConfig)
 	if err != nil {
 		return nil, err
@@ -230,8 +229,8 @@ func OpenClientControlStream(
 // NewClientControlStream returns ClientControlStream from quic Connection and the first stream form the Connection.
 func NewClientControlStream(
 	ctx context.Context, conn Connection, stream ContextReadWriteCloser,
-	codec frame.Codec, packetReadWriter frame.PacketReadWriter, logger *slog.Logger) *ClientControlStream {
-
+	codec frame.Codec, packetReadWriter frame.PacketReadWriter, logger *slog.Logger,
+) *ClientControlStream {
 	controlStream := &ClientControlStream{
 		ctx:                        ctx,
 		conn:                       conn,
@@ -337,7 +336,6 @@ func ackDataStream(stream frame.Reader) (string, error) {
 // If the handshake is successful, a DataStream will be returned by the AcceptStream() method.
 func (cs *ClientControlStream) RequestStream(hf *frame.HandshakeFrame) error {
 	err := cs.stream.WriteFrame(hf)
-
 	if err != nil {
 		return err
 	}
@@ -436,7 +434,7 @@ func (cs *ClientControlStream) acceptStream(ctx context.Context) (DataStream, er
 		return nil, err
 	}
 
-	return newDataStream(f.Name, f.ID, StreamType(f.StreamType), md, f.ObserveDataTags, fs, nil, cs.signalChan), nil
+	return newDataStream(f.Name, f.ID, ClientType(f.ClientType), md, f.ObserveDataTags, fs, nil, cs.signalChan), nil
 }
 
 // CloseWithError closes the client-side control stream.

--- a/core/data_stream.go
+++ b/core/data_stream.go
@@ -16,8 +16,8 @@ type StreamInfo interface {
 	Name() string
 	// ID represents the dataStream ID, the ID is an unique string.
 	ID() string
-	// StreamType represents dataStream type (Source | SFN | UpstreamZipper).
-	StreamType() StreamType
+	// ClientType represents client type (Source | SFN | UpstreamZipper).
+	ClientType() ClientType
 	// Metadata returns the extra info of the application.
 	// The metadata is a merged set of data from both the handshake and authentication processes.
 	Metadata() metadata.M
@@ -37,7 +37,7 @@ type DataStream interface {
 type dataStream struct {
 	name       string
 	id         string
-	streamType StreamType
+	clientType ClientType
 	metadata   metadata.M
 	observed   []frame.Tag
 	stream     *FrameStream
@@ -50,7 +50,7 @@ type dataStream struct {
 func newDataStream(
 	name string,
 	id string,
-	streamType StreamType,
+	clientType ClientType,
 	metadata metadata.M,
 	observed []frame.Tag,
 	stream *FrameStream,
@@ -60,7 +60,7 @@ func newDataStream(
 	return &dataStream{
 		name:       name,
 		id:         id,
-		streamType: streamType,
+		clientType: clientType,
 		metadata:   metadata,
 		observed:   observed,
 		stream:     stream,
@@ -75,7 +75,7 @@ func (s *dataStream) Context() context.Context     { return s.stream.Context() }
 func (s *dataStream) ID() string                   { return s.id }
 func (s *dataStream) Name() string                 { return s.name }
 func (s *dataStream) Metadata() metadata.M         { return s.metadata }
-func (s *dataStream) StreamType() StreamType       { return s.streamType }
+func (s *dataStream) ClientType() ClientType       { return s.clientType }
 func (s *dataStream) ObserveDataTags() []frame.Tag { return s.observed }
 func (s *dataStream) Close() error                 { return s.stream.Close() }
 
@@ -85,6 +85,7 @@ func (s *dataStream) WriteFrame(f frame.Frame) error {
 	}
 	return s.stream.WriteFrame(f)
 }
+
 func (s *dataStream) ReadFrame() (frame.Frame, error) {
 	type outCh struct {
 		frame frame.Frame
@@ -130,39 +131,6 @@ func (s *dataStream) ReadFrame() (frame.Frame, error) {
 	result := <-out
 
 	return result.frame, result.err
-}
-
-const (
-	// StreamTypeSource is stream type "Source".
-	// "Source" type stream sends data to "Stream Function" stream generally.
-	StreamTypeSource StreamType = 0x5F
-
-	// StreamTypeUpstreamZipper is connection type "Upstream Zipper".
-	// "Upstream Zipper" type stream sends data from "Source" to other zipper node.
-	// With "Upstream Zipper", the yomo can run in mesh mode.
-	StreamTypeUpstreamZipper StreamType = 0x5E
-
-	// StreamTypeStreamFunction is stream type "Stream Function".
-	// "Stream Function" handles data from source.
-	StreamTypeStreamFunction StreamType = 0x5D
-)
-
-// StreamType represents the stream type.
-type StreamType byte
-
-var streamTypeStringMap = map[StreamType]string{
-	StreamTypeSource:         "Source",
-	StreamTypeUpstreamZipper: "UpstreamZipper",
-	StreamTypeStreamFunction: "StreamFunction",
-}
-
-// String returns string for StreamType.
-func (c StreamType) String() string {
-	str, ok := streamTypeStringMap[c]
-	if !ok {
-		return "Unknown"
-	}
-	return str
 }
 
 // ContextReadWriteCloser represents a stream which its lifecycle managed by context.

--- a/core/data_stream_test.go
+++ b/core/data_stream_test.go
@@ -17,7 +17,7 @@ func TestDataStream(t *testing.T) {
 		readBytes = []byte("aaabbbcccdddeeefff")
 		name      = "test-data-stream"
 		id        = "123456"
-		styp      = StreamTypeStreamFunction
+		styp      = ClientTypeStreamFunction
 		observed  = []uint32{1, 2, 3}
 		md        metadata.M
 	)
@@ -33,7 +33,7 @@ func TestDataStream(t *testing.T) {
 	t.Run("StreamInfo", func(t *testing.T) {
 		assert.Equal(t, id, stream.ID())
 		assert.Equal(t, name, stream.Name())
-		assert.Equal(t, styp, stream.StreamType())
+		assert.Equal(t, styp, stream.ClientType())
 		assert.Equal(t, md, stream.Metadata())
 		assert.Equal(t, observed, stream.ObserveDataTags())
 	})
@@ -93,11 +93,11 @@ func TestDataStream(t *testing.T) {
 	})
 }
 
-func TestStreamTypeString(t *testing.T) {
-	assert.Equal(t, StreamTypeSource.String(), "Source")
-	assert.Equal(t, StreamTypeStreamFunction.String(), "StreamFunction")
-	assert.Equal(t, StreamTypeUpstreamZipper.String(), "UpstreamZipper")
-	assert.Equal(t, StreamType(0).String(), "Unknown")
+func TestClientTypeString(t *testing.T) {
+	assert.Equal(t, ClientTypeSource.String(), "Source")
+	assert.Equal(t, ClientTypeStreamFunction.String(), "StreamFunction")
+	assert.Equal(t, ClientTypeUpstreamZipper.String(), "UpstreamZipper")
+	assert.Equal(t, ClientType(0).String(), "Unknown")
 }
 
 // byteFrame implements frame.Frame interface for unittest.

--- a/core/frame/frame.go
+++ b/core/frame/frame.go
@@ -74,8 +74,8 @@ type HandshakeFrame struct {
 	Name string
 	// ID is the ID of the dataStream that will be created.
 	ID string
-	// StreamType is the StreamType of the dataStream that will be created.
-	StreamType byte
+	// ClientType is the type of client.
+	ClientType byte
 	// ObserveDataTags is the ObserveDataTags of the dataStream that will be created.
 	ObserveDataTags []Tag
 	// Metadata is the Metadata of the dataStream that will be created.

--- a/core/server.go
+++ b/core/server.go
@@ -481,6 +481,7 @@ func (s *Server) AddDownstreamServer(addr string, c FrameWriterConnection) {
 // dispatch every DataFrames to all downstreams
 func (s *Server) dispatchToDownstreams(c *Context) {
 	if c.DataStream.ClientType() == ClientTypeUpstreamZipper {
+		c.Logger.Warn("ignored client", "client_type", c.DataStream.ClientType().String())
 		// loop protection
 		return
 	}

--- a/core/server.go
+++ b/core/server.go
@@ -431,7 +431,7 @@ func sourceIDTagFindStreamFunc(sourceID string, tag frame.Tag) FindStreamFunc {
 	return func(stream StreamInfo) bool {
 		for _, v := range stream.ObserveDataTags() {
 			if v == tag &&
-				stream.StreamType() == StreamTypeSource &&
+				stream.ClientType() == ClientTypeSource &&
 				stream.ID() == sourceID {
 				return true
 			}
@@ -480,7 +480,7 @@ func (s *Server) AddDownstreamServer(addr string, c FrameWriterConnection) {
 
 // dispatch every DataFrames to all downstreams
 func (s *Server) dispatchToDownstreams(c *Context) {
-	if c.DataStream.StreamType() == StreamTypeUpstreamZipper {
+	if c.DataStream.ClientType() == ClientTypeUpstreamZipper {
 		// loop protection
 		return
 	}

--- a/core/server_test.go
+++ b/core/server_test.go
@@ -13,19 +13,19 @@ func TestMakeSourceTagFindStreamFunc(t *testing.T) {
 	findFunc := sourceIDTagFindStreamFunc("hello", frame.Tag(7))
 
 	t.Run("find successful", func(t *testing.T) {
-		source := &mockStreamInfo{id: "hello", observed: []frame.Tag{frame.Tag(7)}, streamType: StreamTypeSource}
+		source := &mockStreamInfo{id: "hello", observed: []frame.Tag{frame.Tag(7)}, clientType: ClientTypeSource}
 		got := findFunc(source)
 		assert.True(t, got)
 	})
 
 	t.Run("find in name failed", func(t *testing.T) {
-		source := &mockStreamInfo{id: "olleh", observed: []frame.Tag{frame.Tag(7)}, streamType: StreamTypeSource}
+		source := &mockStreamInfo{id: "olleh", observed: []frame.Tag{frame.Tag(7)}, clientType: ClientTypeSource}
 		got := findFunc(source)
 		assert.False(t, got)
 	})
 
 	t.Run("find in tag failed", func(t *testing.T) {
-		source := &mockStreamInfo{id: "hello", observed: []frame.Tag{frame.Tag(6)}, streamType: StreamTypeSource}
+		source := &mockStreamInfo{id: "hello", observed: []frame.Tag{frame.Tag(6)}, clientType: ClientTypeSource}
 		got := findFunc(source)
 		assert.False(t, got)
 	})
@@ -34,7 +34,7 @@ func TestMakeSourceTagFindStreamFunc(t *testing.T) {
 type mockStreamInfo struct {
 	name       string
 	id         string
-	streamType StreamType
+	clientType ClientType
 	metadata   metadata.M
 	observed   []frame.Tag
 }
@@ -42,5 +42,5 @@ type mockStreamInfo struct {
 func (s *mockStreamInfo) ID() string                   { return s.id }
 func (s *mockStreamInfo) Name() string                 { return s.name }
 func (s *mockStreamInfo) Metadata() metadata.M         { return s.metadata }
-func (s *mockStreamInfo) StreamType() StreamType       { return s.streamType }
+func (s *mockStreamInfo) ClientType() ClientType       { return s.clientType }
 func (s *mockStreamInfo) ObserveDataTags() []frame.Tag { return s.observed }

--- a/core/stream_group.go
+++ b/core/stream_group.go
@@ -75,7 +75,7 @@ func (g *StreamGroup) handleRoute(hf *frame.HandshakeFrame, md metadata.M) (rout
 			// if same name sfn here, close the old connection.
 			stream.(*dataStream).serverController.Goaway(e.Error())
 			g.connector.Delete(existsStreamID)
-			g.logger.Debug("connector remove stream", "stream_id", stream.ID(), "stream_type", stream.ClientType().String(), "stream_name", stream.Name())
+			g.logger.Debug("connector remove stream", "stream_id", stream.ID(), "client_type", stream.ClientType().String(), "stream_name", stream.Name())
 		}
 		return route, nil
 	}
@@ -135,7 +135,7 @@ func (g *StreamGroup) Run(contextFunc func(c *Context)) error {
 
 		g.group.Add(1)
 		g.connector.Store(stream.ID(), stream)
-		g.logger.Debug("connector add stream", "stream_id", stream.ID(), "stream_type", stream.ClientType().String(), "stream_name", stream.Name())
+		g.logger.Debug("connector add stream", "stream_id", stream.ID(), "client_type", stream.ClientType().String(), "stream_name", stream.Name())
 
 		go g.handleContextFunc(routeResult.route, stream, contextFunc)
 	}
@@ -148,7 +148,7 @@ func (g *StreamGroup) handleContextFunc(route router.Route, stream DataStream, c
 			route.Remove(stream.ID())
 		}
 		g.connector.Delete(stream.ID())
-		g.logger.Debug("connector remove stream", "stream_id", stream.ID(), "stream_type", stream.ClientType().String(), "stream_name", stream.Name())
+		g.logger.Debug("connector remove stream", "stream_id", stream.ID(), "client_type", stream.ClientType().String(), "stream_name", stream.Name())
 		g.group.Done()
 	}()
 

--- a/core/stream_group.go
+++ b/core/stream_group.go
@@ -50,7 +50,7 @@ func NewStreamGroup(
 }
 
 func (g *StreamGroup) handleRoute(hf *frame.HandshakeFrame, md metadata.M) (router.Route, error) {
-	if hf.StreamType != byte(StreamTypeStreamFunction) {
+	if hf.ClientType != byte(ClientTypeStreamFunction) {
 		return nil, nil
 	}
 	// route for sfn.
@@ -75,7 +75,7 @@ func (g *StreamGroup) handleRoute(hf *frame.HandshakeFrame, md metadata.M) (rout
 			// if same name sfn here, close the old connection.
 			stream.(*dataStream).serverController.Goaway(e.Error())
 			g.connector.Delete(existsStreamID)
-			g.logger.Debug("connector remove stream", "stream_id", stream.ID(), "stream_type", stream.StreamType().String(), "stream_name", stream.Name())
+			g.logger.Debug("connector remove stream", "stream_id", stream.ID(), "stream_type", stream.ClientType().String(), "stream_name", stream.Name())
 		}
 		return route, nil
 	}
@@ -135,7 +135,7 @@ func (g *StreamGroup) Run(contextFunc func(c *Context)) error {
 
 		g.group.Add(1)
 		g.connector.Store(stream.ID(), stream)
-		g.logger.Debug("connector add stream", "stream_id", stream.ID(), "stream_type", stream.StreamType().String(), "stream_name", stream.Name())
+		g.logger.Debug("connector add stream", "stream_id", stream.ID(), "stream_type", stream.ClientType().String(), "stream_name", stream.Name())
 
 		go g.handleContextFunc(routeResult.route, stream, contextFunc)
 	}
@@ -148,7 +148,7 @@ func (g *StreamGroup) handleContextFunc(route router.Route, stream DataStream, c
 			route.Remove(stream.ID())
 		}
 		g.connector.Delete(stream.ID())
-		g.logger.Debug("connector remove stream", "stream_id", stream.ID(), "stream_type", stream.StreamType().String(), "stream_name", stream.Name())
+		g.logger.Debug("connector remove stream", "stream_id", stream.ID(), "stream_type", stream.ClientType().String(), "stream_name", stream.Name())
 		g.group.Done()
 	}()
 

--- a/pkg/frame-codec/y3codec/codec_test.go
+++ b/pkg/frame-codec/y3codec/codec_test.go
@@ -16,7 +16,7 @@ func TestReadPacket(t *testing.T) {
 	hf := &frame.HandshakeFrame{
 		Name:            "a",
 		ID:              "b",
-		StreamType:      0x10,
+		ClientType:      0x10,
 		ObserveDataTags: []uint32{1, 2, 3},
 		Metadata:        []byte{'c'},
 	}
@@ -118,7 +118,7 @@ func TestCodec(t *testing.T) {
 				dataF: &frame.HandshakeFrame{
 					Name:            "the-name",
 					ID:              "the-id",
-					StreamType:      104,
+					ClientType:      104,
 					ObserveDataTags: []uint32{'a', 'b', 'c'},
 					Metadata:        []byte{'d', 'e', 'f'},
 				},
@@ -151,7 +151,8 @@ func TestCodec(t *testing.T) {
 				dataF: &frame.RejectedFrame{
 					Message: "rejected error",
 				},
-				data: []byte{0xb9, 0x10, 0x1, 0xe, 0x72, 0x65, 0x6a, 0x65, 0x63, 0x74, 0x65,
+				data: []byte{
+					0xb9, 0x10, 0x1, 0xe, 0x72, 0x65, 0x6a, 0x65, 0x63, 0x74, 0x65,
 					0x64, 0x20, 0x65, 0x72, 0x72, 0x6f, 0x72,
 				},
 			},
@@ -163,7 +164,8 @@ func TestCodec(t *testing.T) {
 				dataF: &frame.GoawayFrame{
 					Message: "goaway error",
 				},
-				data: []byte{0xae, 0xe, 0x1, 0xc, 0x67, 0x6f, 0x61, 0x77, 0x61, 0x79, 0x20,
+				data: []byte{
+					0xae, 0xe, 0x1, 0xc, 0x67, 0x6f, 0x61, 0x77, 0x61, 0x79, 0x20,
 					0x65, 0x72, 0x72, 0x6f, 0x72,
 				},
 			},

--- a/pkg/frame-codec/y3codec/handshake_frame.go
+++ b/pkg/frame-codec/y3codec/handshake_frame.go
@@ -16,8 +16,8 @@ func encodeHandshakeFrame(f *frame.HandshakeFrame) ([]byte, error) {
 	idBlock := y3.NewPrimitivePacketEncoder(tagHandshakeID)
 	idBlock.SetStringValue(f.ID)
 	// stream type
-	typeBlock := y3.NewPrimitivePacketEncoder(tagHandshakeStreamType)
-	typeBlock.SetBytesValue([]byte{f.StreamType})
+	typeBlock := y3.NewPrimitivePacketEncoder(tagHandshakeClientType)
+	typeBlock.SetBytesValue([]byte{f.ClientType})
 	// observe data tags
 	observeDataTagsBlock := y3.NewPrimitivePacketEncoder(tagHandshakeObserveDataTags)
 	buf := make([]byte, 4)
@@ -63,10 +63,10 @@ func decodeHandshakeFrame(data []byte, f *frame.HandshakeFrame) error {
 		}
 		f.ID = id
 	}
-	// stream type
-	if typeBlock, ok := node.PrimitivePackets[byte(tagHandshakeStreamType)]; ok {
-		streamType := typeBlock.ToBytes()
-		f.StreamType = streamType[0]
+	// client type
+	if typeBlock, ok := node.PrimitivePackets[byte(tagHandshakeClientType)]; ok {
+		clientType := typeBlock.ToBytes()
+		f.ClientType = clientType[0]
 	}
 	// observe data tag list
 	if observeDataTagsBlock, ok := node.PrimitivePackets[byte(tagHandshakeObserveDataTags)]; ok {
@@ -88,7 +88,7 @@ func decodeHandshakeFrame(data []byte, f *frame.HandshakeFrame) error {
 
 var (
 	tagHandshakeName            byte = 0x01
-	tagHandshakeStreamType      byte = 0x02
+	tagHandshakeClientType      byte = 0x02
 	tagHandshakeID              byte = 0x03
 	tagHandshakeObserveDataTags byte = 0x06
 	tagHandshakeMetadata        byte = 0x07

--- a/sfn.go
+++ b/sfn.go
@@ -125,9 +125,9 @@ func (s *streamFunction) Connect() error {
 						var err error
 						// set parent span, if not traced, use empty string
 						if parentTraced {
-							span, err = trace.NewSpan(tp, core.StreamTypeStreamFunction.String(), s.name, tid, sid)
+							span, err = trace.NewSpan(tp, core.ClientTypeStreamFunction.String(), s.name, tid, sid)
 						} else {
-							span, err = trace.NewSpan(tp, core.StreamTypeStreamFunction.String(), s.name, "", "")
+							span, err = trace.NewSpan(tp, core.ClientTypeStreamFunction.String(), s.name, "", "")
 						}
 						if err != nil {
 							s.client.Logger().Error("sfn trace error", "err", err)
@@ -220,9 +220,9 @@ func (s *streamFunction) onDataFrame(dataFrame *frame.DataFrame) {
 				var err error
 				// set parent span, if not traced, use empty string
 				if parentTraced {
-					span, err = trace.NewSpan(tp, core.StreamTypeStreamFunction.String(), s.name, tid, sid)
+					span, err = trace.NewSpan(tp, core.ClientTypeStreamFunction.String(), s.name, tid, sid)
 				} else {
-					span, err = trace.NewSpan(tp, core.StreamTypeStreamFunction.String(), s.name, "", "")
+					span, err = trace.NewSpan(tp, core.ClientTypeStreamFunction.String(), s.name, "", "")
 				}
 				if err != nil {
 					s.client.Logger().Error("sfn trace error", "err", err)

--- a/source.go
+++ b/source.go
@@ -79,7 +79,7 @@ func (s *yomoSource) Write(tag uint32, data []byte) error {
 	tp := s.client.TracerProvider()
 	traced := false
 	if tp != nil {
-		span, err := trace.NewSpan(tp, core.StreamTypeSource.String(), s.name, "", "")
+		span, err := trace.NewSpan(tp, core.ClientTypeSource.String(), s.name, "", "")
 		if err != nil {
 			s.client.Logger().Error("source trace error", "err", err)
 		} else {

--- a/zipper.go
+++ b/zipper.go
@@ -62,7 +62,7 @@ func NewZipper(name string, meshConfig map[string]config.Downstream, options ...
 	server := core.NewServer(name, opts.serverOption...)
 
 	// add downstreams to server.
-	for _, meshConf := range meshConfig {
+	for downstreamName, meshConf := range meshConfig {
 		addr := fmt.Sprintf("%s:%d", meshConf.Host, meshConf.Port)
 
 		clientOptions := append(
@@ -73,7 +73,11 @@ func NewZipper(name string, meshConfig map[string]config.Downstream, options ...
 		)
 		downstream := core.NewClient(name, core.ClientTypeUpstreamZipper, clientOptions...)
 
-		server.Logger().Debug("add downstream", "downstream_addr", addr, "downstream_name", downstream.Name())
+		server.Logger().Debug("add downstream",
+			"downstream_name", downstreamName,
+			"downstream_addr", addr,
+			"client_id", downstream.ClientID(),
+		)
 		server.AddDownstreamServer(addr, downstream)
 	}
 


### PR DESCRIPTION
# Description

Simplify semantics by merging `ClientType` and `StreamType` into `ClientType`.
