### PR TITLE
feat(sfn): stream function is restricted in a single realm

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -32,13 +32,13 @@ func GetRootPath() string {
 }
 
 func parseURL(url string, opts *serverless.Options) error {
+	url = strings.TrimSpace(url)
 	if url == "" {
 		url = "localhost:9000"
 	}
 
-	splits := strings.Split(strings.TrimSpace(url), ":")
-	l := len(splits)
-	if l != 2 {
+	splits := strings.Split(url, ":")
+	if len(splits) != 2 {
 		return fmt.Errorf(`the format of url "%s" is incorrect, it should be "host:port", e.g. localhost:9000`, url)
 	}
 
@@ -46,6 +46,7 @@ func parseURL(url string, opts *serverless.Options) error {
 	if err != nil {
 		return fmt.Errorf("%s: invalid port: %s", url, splits[1])
 	}
+
 	opts.ZipperAddr = fmt.Sprintf("%s:%d", splits[0], port)
 
 	return nil

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -35,26 +35,19 @@ func parseURL(url string, opts *serverless.Options) error {
 	if url == "" {
 		url = "localhost:9000"
 	}
-	addrs := strings.Split(url, ",")
-	for _, addr := range addrs {
-		addr = strings.TrimSpace(addr)
-		if len(addr) == 0 {
-			continue
-		}
-		splits := strings.Split(addr, ":")
-		l := len(splits)
-		if l == 1 {
-			opts.ZipperAddrs = append(opts.ZipperAddrs, splits[0]+":9000")
-		} else if l == 2 {
-			port, err := strconv.Atoi(splits[1])
-			if err != nil {
-				return fmt.Errorf("%s: invalid port: %s", addr, splits[1])
-			}
-			opts.ZipperAddrs = append(opts.ZipperAddrs, fmt.Sprintf("%s:%d", splits[0], port))
-		} else {
-			return fmt.Errorf(`the format of url "%s" is incorrect, it should be "host:port", f.e. localhost:9000`, addr)
-		}
+
+	splits := strings.Split(strings.TrimSpace(url), ":")
+	l := len(splits)
+	if l != 2 {
+		return fmt.Errorf(`the format of url "%s" is incorrect, it should be "host:port", e.g. localhost:9000`, url)
 	}
+
+	port, err := strconv.Atoi(splits[1])
+	if err != nil {
+		return fmt.Errorf("%s: invalid port: %s", url, splits[1])
+	}
+	opts.ZipperAddr = fmt.Sprintf("%s:%d", splits[0], port)
+
 	return nil
 }
 

--- a/cli/dev.go
+++ b/cli/dev.go
@@ -44,7 +44,7 @@ var devCmd = &cobra.Command{
 		log.PendingStatusEvent(os.Stdout, "Create YoMo Stream Function instance...")
 
 		// Connect the serverless to YoMo dev-server, it will automatically emit the mock data.
-		opts.ZipperAddrs = []string{"tap.yomo.dev:9140"}
+		opts.ZipperAddr = "tap.yomo.dev:9140"
 		opts.Name = "yomo-app-demo"
 
 		s, err := serverless.Create(&opts)
@@ -65,7 +65,7 @@ var devCmd = &cobra.Command{
 			os.Stdout,
 			"Starting YoMo Stream Function instance with executable file: %s. Zipper: %v.",
 			opts.Filename,
-			opts.ZipperAddrs,
+			opts.ZipperAddr,
 		)
 		log.InfoStatusEvent(os.Stdout, "YoMo Stream Function is running...")
 		if err := s.Run(verbose); err != nil {

--- a/cli/run.go
+++ b/cli/run.go
@@ -87,7 +87,7 @@ var runCmd = &cobra.Command{
 			"Starting YoMo Stream Function instance with executable file: %s. WasmRuntime: %s. Zipper: %v.",
 			opts.Filename,
 			wasmRuntime,
-			opts.ZipperAddrs,
+			opts.ZipperAddr,
 		)
 		log.InfoStatusEvent(os.Stdout, "YoMo Stream Function is running...")
 		if err := s.Run(verbose); err != nil {
@@ -101,7 +101,7 @@ func init() {
 	rootCmd.AddCommand(runCmd)
 
 	runCmd.Flags().StringVarP(&url, "zipper", "z", "localhost:9000", "YoMo-Zipper endpoint addr")
-	runCmd.Flags().StringVarP(&opts.Name, "name", "n", "", "yomo stream function name. It should match the specific service name in YoMo-Zipper config (config.yaml)")
+	runCmd.Flags().StringVarP(&opts.Name, "name", "n", "", "yomo stream function name.")
 	runCmd.Flags().StringVarP(&opts.ModFile, "modfile", "m", "", "custom go.mod")
 	runCmd.Flags().StringVarP(&opts.Credential, "credential", "d", "", "client credential payload, eg: `token:dBbBiRE7`")
 	runCmd.Flags().StringVarP(&opts.Runtime, "runtime", "r", "", "serverless runtime type")

--- a/cli/serverless/deno/serverless.go
+++ b/cli/serverless/deno/serverless.go
@@ -2,26 +2,22 @@
 package deno
 
 import (
-	"os"
-	"sync"
-
 	"github.com/yomorun/yomo/cli/serverless"
-	"github.com/yomorun/yomo/pkg/log"
 )
 
 // denoServerless will start deno program to run serverless functions.
 type denoServerless struct {
-	name        string
-	fileName    string
-	zipperAddrs []string
-	credential  string
+	name       string
+	fileName   string
+	zipperAddr string
+	credential string
 }
 
 // Init initializes the serverless
 func (s *denoServerless) Init(opts *serverless.Options) error {
 	s.name = opts.Name
 	s.fileName = opts.Filename
-	s.zipperAddrs = opts.ZipperAddrs
+	s.zipperAddr = opts.ZipperAddr
 	s.credential = opts.Credential
 	return nil
 }
@@ -33,21 +29,7 @@ func (s *denoServerless) Build(clean bool) error {
 
 // Run the wasm serverless function
 func (s *denoServerless) Run(verbose bool) error {
-	var wg sync.WaitGroup
-
-	for _, v := range s.zipperAddrs {
-		wg.Add(1)
-		go func(zipperAddr string) {
-			err := run(s.name, zipperAddr, s.credential, s.fileName, "./"+s.name+".sock")
-			if err != nil {
-				log.FailureStatusEvent(os.Stderr, "%v", err)
-			}
-			wg.Done()
-		}(v)
-	}
-
-	wg.Wait()
-	return nil
+	return run(s.name, s.zipperAddr, s.credential, s.fileName, "./"+s.name+".sock")
 }
 
 // Executable shows whether the program needs to be built

--- a/cli/serverless/golang/serverless.go
+++ b/cli/serverless/golang/serverless.go
@@ -49,10 +49,10 @@ func (s *GolangServerless) Init(opts *serverless.Options) error {
 
 	// append main function
 	ctx := Context{
-		Name:        s.opts.Name,
-		ZipperAddrs: s.opts.ZipperAddrs,
-		Credential:  s.opts.Credential,
-		UseEnv:      s.opts.UseEnv,
+		Name:       s.opts.Name,
+		ZipperAddr: s.opts.ZipperAddr,
+		Credential: s.opts.Credential,
+		UseEnv:     s.opts.UseEnv,
 	}
 
 	// determine: rx stream serverless or raw bytes serverless.

--- a/cli/serverless/golang/template.go
+++ b/cli/serverless/golang/template.go
@@ -34,8 +34,8 @@ var WasmMainFuncTmpl []byte
 type Context struct {
 	// Name of the servcie
 	Name string
-	// ZipperAddrs is the addresses of the zipper server
-	ZipperAddrs []string
+	// ZipperAddrs is the address of the zipper server
+	ZipperAddr string
 	// Client credential
 	Credential string
 	// use environment variables

--- a/cli/serverless/options.go
+++ b/cli/serverless/options.go
@@ -4,8 +4,8 @@ package serverless
 type Options struct {
 	// Filename is the path to the serverless file.
 	Filename string
-	// ZipperAddrs is the addresses of the zipper server
-	ZipperAddrs []string
+	// ZipperAddrs is the address of the zipper server
+	ZipperAddr string
 	// Name is the name of the service.
 	Name string
 	// ModFile is the path to the module file.


### PR DESCRIPTION
# Description

We introduce the realm concept to stand for a group of services within a unique geo-zone, and there is only one zipper service in a single realm. Therefore a single SFN instance should belong to a single realm.

## Impact

Now serverless functions cannot connect to  multiple zippers.