### PR TITLE
style: improve zipper log readability

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -54,7 +54,7 @@ go run main.go
 
 #### Write the serverless function
 
-See [../example/9-cli/sfn/main.go](../example/9-cli/sfn/main.go)
+See [../example/9-cli/sfn/app.go](../example/9-cli/sfn/app.go)
 
 #### Build
 

--- a/core/client.go
+++ b/core/client.go
@@ -333,6 +333,7 @@ func (c *Client) Name() string { return c.name }
 // FrameWriterConnection represents a frame writer that can connect to an addr.
 type FrameWriterConnection interface {
 	frame.Writer
+	ClientID() string
 	Name() string
 	Close() error
 	Connect(context.Context, string) error

--- a/core/client_test.go
+++ b/core/client_test.go
@@ -63,7 +63,7 @@ func TestFrameRoundTrip(t *testing.T) {
 	recorder := newFrameWriterRecorder("mockClient")
 	server.AddDownstreamServer("mockAddr", recorder)
 
-	assert.Equal(t, map[string]string{"mockAddr": "mockClient"}, server.Downstreams())
+	assert.Equal(t, server.Downstreams()["mockAddr"], recorder.ClientID())
 
 	go func() {
 		err := server.ListenAndServe(ctx, testaddr)

--- a/core/client_test.go
+++ b/core/client_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/yomorun/yomo/core/router"
 	"github.com/yomorun/yomo/core/ylog"
 	"github.com/yomorun/yomo/pkg/frame-codec/y3codec"
+	"github.com/yomorun/yomo/pkg/id"
 )
 
 const testaddr = "127.0.0.1:19999"
@@ -224,6 +225,7 @@ func createTestStreamFunction(name string, observedTag frame.Tag) *Client {
 
 // frameWriterRecorder frames be writen.
 type frameWriterRecorder struct {
+	id           string
 	name         string
 	codec        frame.Codec
 	packetReader frame.PacketReadWriter
@@ -233,6 +235,7 @@ type frameWriterRecorder struct {
 
 func newFrameWriterRecorder(name string) *frameWriterRecorder {
 	return &frameWriterRecorder{
+		id:           id.New(),
 		name:         name,
 		codec:        y3codec.Codec(),
 		packetReader: y3codec.PacketReadWriter(),
@@ -240,6 +243,7 @@ func newFrameWriterRecorder(name string) *frameWriterRecorder {
 	}
 }
 
+func (w *frameWriterRecorder) ClientID() string                          { return w.id }
 func (w *frameWriterRecorder) Name() string                              { return w.name }
 func (w *frameWriterRecorder) Close() error                              { return nil }
 func (w *frameWriterRecorder) Connect(_ context.Context, _ string) error { return nil }

--- a/core/context.go
+++ b/core/context.go
@@ -98,12 +98,6 @@ func newContext(conn Connection, route router.Route, logger *slog.Logger) (c *Co
 		c = v.(*Context)
 	}
 
-	logger = logger.With(
-		"conn_id", conn.ID(),
-		"conn_name", conn.Name(),
-		"conn_type", conn.ClientType().String(),
-	)
-
 	c.Connection = conn
 	c.Route = route
 	c.BaseLogger = logger
@@ -129,8 +123,6 @@ func (c *Context) WithFrame(f frame.Frame) error {
 	if err != nil {
 		return err
 	}
-
-	c.Logger = c.BaseLogger.With(MetadataSlogAttr(fmd))
 
 	// merge connection metadata.
 	c.Connection.Metadata().Range(func(k, v string) bool {

--- a/core/router/default_test.go
+++ b/core/router/default_test.go
@@ -25,7 +25,7 @@ func TestRouter(t *testing.T) {
 	assert.NoError(t, err)
 
 	ids := route.GetForwardRoutes(frame.Tag(1))
-	assert.Equal(t, []string{"conn-1", "conn-2", "conn-3"}, ids)
+	assert.ElementsMatch(t, []string{"conn-1", "conn-2", "conn-3"}, ids)
 
 	err = route.Remove("conn-1")
 	assert.NoError(t, err)

--- a/core/server.go
+++ b/core/server.go
@@ -399,13 +399,13 @@ func (s *Server) handleDataFrame(c *Context) error {
 	}
 
 	// find stream function ids from the route.
-	streamIDs := route.GetForwardRoutes(dataFrame.Tag)
-	if len(streamIDs) == 0 {
+	connIDs := route.GetForwardRoutes(dataFrame.Tag)
+	if len(connIDs) == 0 {
 		c.Logger.Info("no observed", "tag", dataFrame.Tag, "data_length", data_length)
 	}
-	c.Logger.Debug("connector snapshot", "tag", dataFrame.Tag, "sfn_stream_ids", streamIDs, "connector", s.connector.Snapshot())
+	c.Logger.Debug("connector snapshot", "tag", dataFrame.Tag, "sfn_conn_ids", connIDs, "connector", s.connector.Snapshot())
 
-	for _, toID := range streamIDs {
+	for _, toID := range connIDs {
 		stream, ok, err := s.connector.Get(toID)
 		if err != nil {
 			continue

--- a/example/4-cascading-zipper/zipper_1.yaml
+++ b/example/4-cascading-zipper/zipper_1.yaml
@@ -1,11 +1,11 @@
-name: Zipper-1
+name: zipper-1
 host: 0.0.0.0
 port: 9001
 auth:
   type: token
   token: z1
 downstreams:
-  Zipper-2:
+  zipper-2:
     host: 127.0.0.1
     port: 9002
     credential: "token:z2"

--- a/example/4-cascading-zipper/zipper_2.yaml
+++ b/example/4-cascading-zipper/zipper_2.yaml
@@ -5,7 +5,7 @@ auth:
   type: token
   token: z2
 downstreams:
-  Zipper-1:
+  zipper-1:
     host: 127.0.0.1
     port: 9001
     credential: "token:z1"

--- a/zipper.go
+++ b/zipper.go
@@ -73,11 +73,7 @@ func NewZipper(name string, meshConfig map[string]config.Downstream, options ...
 		)
 		downstream := core.NewClient(name, core.ClientTypeUpstreamZipper, clientOptions...)
 
-		server.Logger().Debug("add downstream",
-			"downstream_name", downstreamName,
-			"downstream_addr", addr,
-			"client_id", downstream.ClientID(),
-		)
+		server.Logger().Info("add downstream", "name", downstreamName, "addr", addr, "downstream_id", downstream.ClientID())
 		server.AddDownstreamServer(addr, downstream)
 	}
 


### PR DESCRIPTION
```sh
wujunzhuo@wujunzhuo-macbook yomo % yomo serve --config example/config.yaml
ℹ️   Running YoMo-Zipper...
time=2023-09-22T10:16:42.036+08:00 level=INFO msg="using config file" component=zipper zipper_name=Service file_path=example/config.yaml
time=2023-09-22T10:16:42.036+08:00 level=INFO msg="Listening SIGUSR1, SIGUSR2, SIGTERM/SIGINT..."
time=2023-09-22T10:16:42.037+08:00 level=INFO msg="zipper is up and running" component=zipper zipper_name=Service zipper_addr=[::]:9000 pid=15846 quic="[v1 v2]" auth_name=[none]
time=2023-09-22T10:16:42.106+08:00 level=INFO msg="client connected" component=zipper zipper_name=Service conn_id=TJEJJfuAxPKnYDhMyQeUa conn_name=sink remote_addr=127.0.0.1:50988 client_type=StreamFunction
time=2023-09-22T10:16:43.207+08:00 level=INFO msg="client connected" component=zipper zipper_name=Service conn_id=W_b6xrGOS0OlbfGWyz16s conn_name=source remote_addr=127.0.0.1:59560 client_type=Source
time=2023-09-22T10:16:43.208+08:00 level=INFO msg="no observed" component=zipper zipper_name=Service conn_id=W_b6xrGOS0OlbfGWyz16s conn_name=source tag=51 data_length=17
time=2023-09-22T10:16:44.209+08:00 level=INFO msg="no observed" component=zipper zipper_name=Service conn_id=W_b6xrGOS0OlbfGWyz16s conn_name=source tag=51 data_length=17
time=2023-09-22T10:16:45.211+08:00 level=INFO msg="no observed" component=zipper zipper_name=Service conn_id=W_b6xrGOS0OlbfGWyz16s conn_name=source tag=51 data_length=17
time=2023-09-22T10:16:46.211+08:00 level=INFO msg="no observed" component=zipper zipper_name=Service conn_id=W_b6xrGOS0OlbfGWyz16s conn_name=source tag=51 data_length=17
time=2023-09-22T10:16:46.949+08:00 level=INFO msg="client connected" component=zipper zipper_name=Service conn_id=sawfDTIRTxrbfo2KC1rid conn_name=sfn-app remote_addr=127.0.0.1:51081 client_type=StreamFunction
time=2023-09-22T10:16:47.212+08:00 level=INFO msg="data routing" component=zipper zipper_name=Service conn_id=W_b6xrGOS0OlbfGWyz16s conn_name=source tid=44e1d9d199f29a9fd30dcd40f298e043 sid=3529e1f69d7cc544 tag=51 data_length=17 to_id=sawfDTIRTxrbfo2KC1rid to_name=sfn-app
time=2023-09-22T10:16:47.214+08:00 level=INFO msg="data routing" component=zipper zipper_name=Service conn_id=sawfDTIRTxrbfo2KC1rid conn_name=sfn-app tid=44e1d9d199f29a9fd30dcd40f298e043 sid=aa2954c43cdfaed2 tag=52 data_length=17 to_id=TJEJJfuAxPKnYDhMyQeUa to_name=sink
time=2023-09-22T10:16:48.214+08:00 level=INFO msg="data routing" component=zipper zipper_name=Service conn_id=W_b6xrGOS0OlbfGWyz16s conn_name=source tid=3fca64fc891db8a99b52f32623cd32ee sid=e4460707ecb1aa32 tag=51 data_length=17 to_id=sawfDTIRTxrbfo2KC1rid to_name=sfn-app
time=2023-09-22T10:16:48.214+08:00 level=INFO msg="data routing" component=zipper zipper_name=Service conn_id=sawfDTIRTxrbfo2KC1rid conn_name=sfn-app tid=3fca64fc891db8a99b52f32623cd32ee sid=e423466d41368d5c tag=52 data_length=17 to_id=TJEJJfuAxPKnYDhMyQeUa to_name=sink
time=2023-09-22T10:16:49.215+08:00 level=INFO msg="data routing" component=zipper zipper_name=Service conn_id=W_b6xrGOS0OlbfGWyz16s conn_name=source tid=5f698e322540aaf11e32c3145a588d84 sid=fded83a2d0cefdbc tag=51 data_length=17 to_id=sawfDTIRTxrbfo2KC1rid to_name=sfn-app
time=2023-09-22T10:16:49.216+08:00 level=INFO msg="data routing" component=zipper zipper_name=Service conn_id=sawfDTIRTxrbfo2KC1rid conn_name=sfn-app tid=5f698e322540aaf11e32c3145a588d84 sid=9ffe99e30ee2ba1e tag=52 data_length=17 to_id=TJEJJfuAxPKnYDhMyQeUa to_name=sink
time=2023-09-22T10:16:50.216+08:00 level=INFO msg="data routing" component=zipper zipper_name=Service conn_id=W_b6xrGOS0OlbfGWyz16s conn_name=source tid=95e36786b082ce776fd28e74d06cd06d sid=0511d2b9778ac0b7 tag=51 data_length=17 to_id=sawfDTIRTxrbfo2KC1rid to_name=sfn-app
```