### PR TITLE
feat: zipper support middleware

### DIFF
--- a/core/client_test.go
+++ b/core/client_test.go
@@ -61,7 +61,7 @@ func TestFrameRoundTrip(t *testing.T) {
 	recorder := newFrameWriterRecorder("mockID", "mockClientLocal", "mockClientRemote")
 	server.AddDownstreamServer(recorder)
 
-	assert.Equal(t, server.Downstreams()["mockID"], recorder.ID())
+	assert.Equal(t, server.Downstreams()["mockClientLocal"], recorder.ID())
 
 	go func() {
 		err := server.ListenAndServe(ctx, testaddr)

--- a/core/client_test.go
+++ b/core/client_test.go
@@ -45,19 +45,18 @@ func TestFrameRoundTrip(t *testing.T) {
 		backflow    = []byte("hello backflow frame")
 	)
 
+	// test server hooks
+	ht := &hookTester{t: t}
+
 	server := NewServer("zipper",
 		WithAuth("token", "auth-token"),
 		WithServerQuicConfig(DefalutQuicConfig),
 		WithServerTLSConfig(nil),
 		WithServerLogger(discardingLogger),
+		WithConnMiddleware(ht.connMiddleware),
+		WithFrameMiddleware(ht.frameMiddleware),
 	)
 	server.ConfigRouter(router.Default())
-
-	// test server hooks
-	ht := &hookTester{t}
-	server.SetStartHandlers(ht.startHandler)
-	server.SetBeforeHandlers(ht.beforeHandler)
-	server.SetAfterHandlers(ht.afterHandler)
 
 	recorder := newFrameWriterRecorder("mockID", "mockClientLocal", "mockClientRemote")
 	server.AddDownstreamServer(recorder)
@@ -191,29 +190,36 @@ func checkClientExited(client *Client, tim time.Duration) bool {
 }
 
 type hookTester struct {
-	t *testing.T
+	mu        sync.Mutex
+	connNames []string
+	t         *testing.T
 }
 
-func (a *hookTester) startHandler(ctx *Context) error {
-	ctx.Set("start", "yes")
-	return nil
+func (a *hookTester) connMiddleware(next ConnHandler) ConnHandler {
+	return func(c *Connection, r router.Route) {
+		a.mu.Lock()
+		if a.connNames == nil {
+			a.connNames = make([]string, 0)
+		}
+		a.connNames = append(a.connNames, c.Name())
+		a.mu.Unlock()
+
+		next(c, r)
+
+		a.mu.Lock()
+		assert.Contains(a.t, a.connNames, c.Name())
+		a.mu.Unlock()
+	}
 }
 
-func (a *hookTester) beforeHandler(ctx *Context) error {
-	ctx.Set("before", "ok")
-	return nil
-}
-
-func (a *hookTester) afterHandler(ctx *Context) error {
-	v, ok := ctx.Get("start")
-	assert.True(a.t, ok)
-	assert.Equal(a.t, v, "yes")
-
-	v = ctx.Value("before")
-	assert.True(a.t, ok)
-	assert.Equal(a.t, v, "ok")
-
-	return nil
+func (a *hookTester) frameMiddleware(next FrameHandler) FrameHandler {
+	return func(c *Context) {
+		c.Set("a", "b")
+		next(c)
+		v, ok := c.Get("a")
+		assert.True(a.t, ok)
+		assert.Equal(a.t, "b", v)
+	}
 }
 
 func createTestStreamFunction(name string, zipperAddr string, observedTag frame.Tag) *Client {

--- a/core/connection.go
+++ b/core/connection.go
@@ -23,8 +23,8 @@ type ConnectionInfo interface {
 	ObserveDataTags() []frame.Tag
 }
 
-// Connection wraps conneciton and stream to transfer frames.
-// Connection be used to read and write frames, and be managed by Connector.
+// Connection wraps connection and stream for transmitting frames, it can be
+// used for reading and writing frames, and is managed by the Connector.
 type Connection struct {
 	name            string
 	id              string
@@ -57,42 +57,52 @@ func newConnection(
 	}
 }
 
+// Close closes the connection.
 func (c *Connection) Close() error {
 	return c.fs.Close()
 }
 
+// Context returns the context of the connection.
 func (c *Connection) Context() context.Context {
 	return c.fs.Context()
 }
 
+// ID returns the connection ID.
 func (c *Connection) ID() string {
 	return c.id
 }
 
+// Metadata returns the extra info of the application.
 func (c *Connection) Metadata() metadata.M {
 	return c.metadata
 }
 
+// Name returns the name of the connection
 func (c *Connection) Name() string {
 	return c.name
 }
 
+// ObserveDataTags returns the observed data tags.
 func (c *Connection) ObserveDataTags() []uint32 {
 	return c.observeDataTags
 }
 
+// ReadFrame reads a frame from the connection.
 func (c *Connection) ReadFrame() (frame.Frame, error) {
 	return c.fs.ReadFrame()
 }
 
+// ClientType returns the client type of the connection.
 func (c *Connection) ClientType() ClientType {
 	return c.clientType
 }
 
+// WriteFrame writes a frame to the connection.
 func (c *Connection) WriteFrame(f frame.Frame) error {
 	return c.fs.WriteFrame(f)
 }
 
+// CloseWithError closes the connection with error.
 func (c *Connection) CloseWithError(errString string) error {
 	return c.conn.CloseWithError(YomoCloseErrorCode, errString)
 }

--- a/core/connection_test.go
+++ b/core/connection_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/yomorun/yomo/core/frame"
 	"github.com/yomorun/yomo/core/metadata"
+	"golang.org/x/exp/slog"
 )
 
 func TestConnection(t *testing.T) {
@@ -30,7 +31,7 @@ func TestConnection(t *testing.T) {
 	// create frame connection.
 	fs := NewFrameStream(mockStream, &byteCodec{}, &bytePacketReadWriter{})
 
-	connection := newConnection(name, id, styp, md, observed, nil, fs)
+	connection := newConnection(name, id, styp, md, observed, nil, fs, slog.Default())
 
 	t.Run("ConnectionInfo", func(t *testing.T) {
 		assert.Equal(t, id, connection.ID())

--- a/core/connector_test.go
+++ b/core/connector_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/yomorun/yomo/core/frame"
+	"golang.org/x/exp/slog"
 )
 
 func TestConnector(t *testing.T) {
@@ -37,10 +38,9 @@ func TestConnector(t *testing.T) {
 		err = connector.Remove(connID)
 		assert.NoError(t, err)
 
-		gotStream, ok, err := connector.Get(connID)
+		_, ok, err := connector.Get(connID)
 		assert.NoError(t, err)
 		assert.False(t, ok)
-		assert.Equal(t, gotStream, nil)
 	})
 
 	t.Run("Find", func(t *testing.T) {
@@ -92,9 +92,8 @@ func TestConnector(t *testing.T) {
 
 		t.Run("Get", func(t *testing.T) {
 			conn1 := mockConn("id-1", "name-1")
-			gotStream, ok, err := connector.Get(conn1.ID())
+			_, ok, err := connector.Get(conn1.ID())
 			assert.False(t, ok)
-			assert.Equal(t, gotStream, nil)
 			assert.ErrorIs(t, err, ErrConnectorClosed)
 		})
 
@@ -117,6 +116,6 @@ func TestConnector(t *testing.T) {
 
 // mockConn returns a connection that only includes an ID and a name.
 // This function is used for unit testing purposes.
-func mockConn(id, name string) Connection {
-	return newConnection(name, id, ClientType(0), nil, []frame.Tag{0}, nil, nil)
+func mockConn(id, name string) *Connection {
+	return newConnection(name, id, ClientType(0), nil, []frame.Tag{0}, nil, nil, slog.Default())
 }

--- a/core/context.go
+++ b/core/context.go
@@ -13,14 +13,13 @@ import (
 
 var ctxPool sync.Pool
 
-// Context is context for connection handling.
-// Context is generated subsequent to the arrival of a connection and retains pertinent information derived from the connection.
-// The lifespan of the Context should align with the lifespan of the connection.
+// Context is context for frame handling.
+// The lifespan of the Context should align with the lifespan of the frame.
 type Context struct {
 	// Connection is the connection used for reading and writing frames.
-	Connection Connection
+	Connection *Connection
 	// Frame receives from client.
-	Frame frame.Frame
+	Frame *frame.DataFrame
 	// FrameMetadata is the merged metadata from the frame.
 	FrameMetadata metadata.M
 	// Route is the route from handshake.
@@ -29,8 +28,6 @@ type Context struct {
 	mu sync.RWMutex
 	// Keys stores the key/value pairs in context, It is Lazy initialized.
 	Keys map[string]any
-	// BaseLogger is the base logger.
-	BaseLogger *slog.Logger
 	// Using Logger to log in connection handler scope, Logger is frame-level logger.
 	Logger *slog.Logger
 }
@@ -89,7 +86,18 @@ func (c *Context) Value(key any) any {
 // The YoMo context is used to manage the lifecycle of a connection and provides a way to pass data and metadata
 // between connection processing functions. The lifecycle of the context is equal to the lifecycle of the connection
 // that it is associated with. The context can be used to manage timeouts, cancellations, and other aspects of connection processing.
-func newContext(conn Connection, route router.Route, logger *slog.Logger) (c *Context) {
+func newContext(conn *Connection, route router.Route, df *frame.DataFrame) (c *Context, err error) {
+	fmd, err := metadata.Decode(df.Metadata)
+	if err != nil {
+		return nil, err
+	}
+
+	// merge connection metadata.
+	conn.Metadata().Range(func(k, v string) bool {
+		fmd.Set(k, v)
+		return true
+	})
+
 	v := ctxPool.Get()
 	if v == nil {
 		c = new(Context)
@@ -97,45 +105,16 @@ func newContext(conn Connection, route router.Route, logger *slog.Logger) (c *Co
 		c = v.(*Context)
 	}
 
-	c.Connection = conn
-	c.Route = route
-	c.BaseLogger = logger
-	c.Logger = logger
-
-	return
-}
-
-// WithFrame sets the current frame of the YoMo context to the given frame.
-// It extracts the metadata from the data frame and sets it as attributes on the context logger.
-// It also merges the metadata from the connection with the metadata from the data frame.
-// This allows downstream processing functions to access the metadata from both the connection and the current data frame.
-// If the given frame is not a data frame, it returns an error.
-// If there is an error decoding the metadata from the data frame, it returns that error.
-// Otherwise, it sets the current frame and frame metadata on the context and returns nil.
-func (c *Context) WithFrame(f frame.Frame) error {
-	df, ok := f.(*frame.DataFrame)
-	if !ok {
-		return nil
-	}
-
-	fmd, err := metadata.Decode(df.Metadata)
-	if err != nil {
-		return err
-	}
-
-	// merge connection metadata.
-	c.Connection.Metadata().Range(func(k, v string) bool {
-		fmd.Set(k, v)
-		return true
-	})
-
 	c.Frame = df
 	c.FrameMetadata = fmd
 
-	// log with tid
-	c.Logger = c.BaseLogger.With("tid", GetTIDFromMetadata(fmd))
+	c.Connection = conn
+	c.Route = route
 
-	return nil
+	// log with tid
+	c.Logger = c.Connection.Logger.With("tid", GetTIDFromMetadata(fmd))
+
+	return
 }
 
 // CloseWithError close dataStream with an error string.
@@ -162,7 +141,6 @@ func (c *Context) reset() {
 	c.Route = nil
 	c.Frame = nil
 	c.FrameMetadata = nil
-	c.BaseLogger = nil
 	c.Logger = nil
 	for k := range c.Keys {
 		delete(c.Keys, k)

--- a/core/server.go
+++ b/core/server.go
@@ -431,8 +431,8 @@ func (s *Server) Downstreams() map[string]string {
 	defer s.mu.Unlock()
 
 	snapshotOfDownstream := make(map[string]string, len(s.downstreams))
-	for addr, client := range s.downstreams {
-		snapshotOfDownstream[addr] = client.ID()
+	for _, client := range s.downstreams {
+		snapshotOfDownstream[client.LocalName()] = client.ID()
 	}
 	return snapshotOfDownstream
 }

--- a/core/server.go
+++ b/core/server.go
@@ -105,7 +105,11 @@ func (s *Server) ListenAndServe(ctx context.Context, addr string) error {
 
 	// connect to all downstreams.
 	for _, client := range s.downstreams {
-		go client.Connect(ctx)
+		go func() {
+			if err := client.Connect(ctx); err != nil {
+				s.logger.Error("failed to connect downstream", "downstream_name", client.LocalName(), "err", err)
+			}
+		}()
 	}
 
 	return s.Serve(ctx, conn)

--- a/core/server.go
+++ b/core/server.go
@@ -154,6 +154,12 @@ func (s *Server) handshake(qconn quic.Connection, fs *FrameStream) (bool, router
 }
 
 func (s *Server) handleConnRoute(conn *Connection, route router.Route) {
+	defer func() {
+		if conn.ClientType() == ClientTypeStreamFunction {
+			_ = route.Remove(conn.ID())
+		}
+		_ = s.connector.Remove(conn.ID())
+	}()
 	for {
 		f, err := conn.ReadFrame()
 		if err != nil {
@@ -183,13 +189,6 @@ func (s *Server) handleQuicConnection(qconn quic.Connection, fs *FrameStream, lo
 		logger.Error("handshake failed")
 		return
 	}
-
-	defer func() {
-		if conn.ClientType() == ClientTypeStreamFunction {
-			_ = route.Remove(conn.ID())
-		}
-		_ = s.connector.Remove(conn.ID())
-	}()
 
 	s.connHandler(conn, route)
 }

--- a/core/server.go
+++ b/core/server.go
@@ -209,7 +209,11 @@ func (s *Server) handleHandshakeFrame(qconn quic.Connection, fs *FrameStream, hf
 	md, ok := auth.Authenticate(s.opts.auths, hf)
 
 	if !ok {
-		s.logger.Warn("authentication failed", "credential", hf.AuthName)
+		s.logger.Warn(
+			"authentication failed",
+			"client_type", ClientType(hf.ClientType).String(), "client_name", hf.Name,
+			"credential", hf.AuthName,
+		)
 		return nil, fmt.Errorf("authentication failed: client credential name is %s", hf.AuthName)
 	}
 

--- a/core/server.go
+++ b/core/server.go
@@ -105,11 +105,7 @@ func (s *Server) ListenAndServe(ctx context.Context, addr string) error {
 
 	// connect to all downstreams.
 	for _, client := range s.downstreams {
-		go func() {
-			if err := client.Connect(ctx); err != nil {
-				s.logger.Error("failed to connect downstream", "downstream_name", client.LocalName(), "err", err)
-			}
-		}()
+		go client.Connect(ctx)
 	}
 
 	return s.Serve(ctx, conn)

--- a/core/server_options.go
+++ b/core/server_options.go
@@ -29,11 +29,13 @@ type ServerOption func(*serverOptions)
 
 // serverOptions are the options for YoMo server.
 type serverOptions struct {
-	quicConfig     *quic.Config
-	tlsConfig      *tls.Config
-	auths          map[string]auth.Authentication
-	logger         *slog.Logger
-	tracerProvider oteltrace.TracerProvider
+	quicConfig       *quic.Config
+	tlsConfig        *tls.Config
+	auths            map[string]auth.Authentication
+	logger           *slog.Logger
+	tracerProvider   oteltrace.TracerProvider
+	connMiddlewares  []ConnMiddleware
+	frameMiddlewares []FrameMiddleware
 }
 
 func defaultServerOptions() *serverOptions {
@@ -86,5 +88,19 @@ func WithServerLogger(logger *slog.Logger) ServerOption {
 func WithServerTracerProvider(tp oteltrace.TracerProvider) ServerOption {
 	return func(o *serverOptions) {
 		o.tracerProvider = tp
+	}
+}
+
+// WithFrameMiddleware sets frame middleware for the client.
+func WithFrameMiddleware(mws ...FrameMiddleware) ServerOption {
+	return func(o *serverOptions) {
+		o.frameMiddlewares = mws
+	}
+}
+
+// WithConnMiddleware sets conn middleware for the client.
+func WithConnMiddleware(mws ...ConnMiddleware) ServerOption {
+	return func(o *serverOptions) {
+		o.connMiddlewares = mws
 	}
 }

--- a/core/server_options.go
+++ b/core/server_options.go
@@ -94,7 +94,7 @@ func WithServerTracerProvider(tp oteltrace.TracerProvider) ServerOption {
 // WithFrameMiddleware sets frame middleware for the client.
 func WithFrameMiddleware(mws ...FrameMiddleware) ServerOption {
 	return func(o *serverOptions) {
-		o.connMiddlewares = append(o.connMiddlewares, mws...)
+		o.frameMiddlewares = append(o.frameMiddlewares, mws...)
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -110,4 +110,18 @@ var (
 			o.serverOption = append(o.serverOption, core.WithServerTracerProvider(tp))
 		}
 	}
+
+	// WithConnMiddleware sets conn middleware for the zipper.
+	WithConnMiddleware = func(mw ...core.ConnMiddleware) ZipperOption {
+		return func(o *zipperOptions) {
+			o.serverOption = append(o.serverOption, core.WithConnMiddleware(mw...))
+		}
+	}
+
+	// WithFrameMiddleware sets frame middleware for the zipper.
+	WithFrameMiddleware = func(mw ...core.FrameMiddleware) ZipperOption {
+		return func(o *zipperOptions) {
+			o.serverOption = append(o.serverOption, core.WithFrameMiddleware(mw...))
+		}
+	}
 )

--- a/zipper.go
+++ b/zipper.go
@@ -66,14 +66,12 @@ func NewZipper(name string, meshConfig map[string]config.Downstream, options ...
 	for downstreamName, meshConf := range meshConfig {
 		addr := fmt.Sprintf("%s:%d", meshConf.Host, meshConf.Port)
 
-		dsLogger := server.Logger().With("downstream_name", downstreamName, "downstream_addr", addr)
-
 		clientOptions := append(
 			opts.clientOption,
 			core.WithCredential(meshConf.Credential),
 			core.WithNonBlockWrite(),
 			core.WithConnectUntilSucceed(),
-			core.WithLogger(dsLogger),
+			core.WithLogger(server.Logger().With("downstream_name", downstreamName, "downstream_addr", addr)),
 		)
 
 		downstream := &downstream{


### PR DESCRIPTION
# Description

Adding `WithConnMiddleware()` and `WithFrameMiddleware()` zipper option, their type is below:

```go
type (
	// FrameHandler handles a frame.
	FrameHandler func(*Context)
	// FrameMiddleware is a middleware for frame handler.
	FrameMiddleware func(FrameHandler) FrameHandler
)

type (
	// ConnHandler handles a connection and route.
	ConnHandler func(*Connection, router.Route)
	// ConnMiddleware is a middleware for connection handler.
	ConnMiddleware func(ConnHandler) ConnHandler
)
```
