### PR TITLE
fix(zipper): improve error description when auth

### DIFF
--- a/core/server.go
+++ b/core/server.go
@@ -240,7 +240,7 @@ func (s *Server) handleHandshakeFrame(fconn frame.Conn, hf *frame.HandshakeFrame
 			"client_type", ClientType(hf.ClientType).String(), "client_name", hf.Name,
 			"credential", hf.AuthName,
 		)
-		return nil, fmt.Errorf("authentication failed: client credential name is %s", hf.AuthName)
+		return nil, fmt.Errorf("authentication failed: client credential type is %s", hf.AuthName)
 	}
 
 	conn := newConnection(hf.Name, hf.ID, ClientType(hf.ClientType), md, hf.ObserveDataTags, fconn, s.logger)


### PR DESCRIPTION
change error description from `authentication failed: client credential name is token` to `authentication failed: client credential type is token`.