### PR TITLE
feat: connectToFrame codec

### DIFF
--- a/core/frame/frame.go
+++ b/core/frame/frame.go
@@ -17,6 +17,7 @@ import (
 //  3. DataFrame
 //  4. RejectedFrame
 //  5. GoawayFrame
+//  6. ConnectToFrame
 //
 // Read frame comments to understand the role of the frame.
 type Frame interface {
@@ -89,12 +90,22 @@ type GoawayFrame struct {
 // Type returns the type of GoawayFrame.
 func (f *GoawayFrame) Type() Type { return TypeGoawayFrame }
 
+// ConnectToFrame is is used by server notify client to connect to a new endpoint.
+type ConnectToFrame struct {
+	// Endpoint is the new endpoint that will be connected by client.
+	Endpoint string
+}
+
+// Type returns the type of ConnectToFrame.
+func (f *ConnectToFrame) Type() Type { return TypeConnectToFrame }
+
 const (
 	TypeDataFrame         Type = 0x3F // TypeDataFrame is the type of DataFrame.
 	TypeHandshakeFrame    Type = 0x31 // TypeHandshakeFrame is the type of HandshakeFrame.
 	TypeHandshakeAckFrame Type = 0x29 // TypeHandshakeAckFrame is the type of HandshakeAckFrame.
 	TypeRejectedFrame     Type = 0x39 // TypeRejectedFrame is the type of RejectedFrame.
 	TypeGoawayFrame       Type = 0x2E // TypeGoawayFrame is the type of GoawayFrame.
+	TypeConnectToFrame    Type = 0x3E // TypeConnectToFrame is the type of ConnectToFrame.
 )
 
 var frameTypeStringMap = map[Type]string{
@@ -103,6 +114,7 @@ var frameTypeStringMap = map[Type]string{
 	TypeHandshakeAckFrame: "HandshakeAckFrame",
 	TypeRejectedFrame:     "RejectedFrame",
 	TypeGoawayFrame:       "GoawayFrame",
+	TypeConnectToFrame:    "ConnectToFrame",
 }
 
 // String returns a human-readable string which represents the frame type.
@@ -121,6 +133,7 @@ var frameTypeNewFuncMap = map[Type]func() Frame{
 	TypeHandshakeAckFrame: func() Frame { return new(HandshakeAckFrame) },
 	TypeRejectedFrame:     func() Frame { return new(RejectedFrame) },
 	TypeGoawayFrame:       func() Frame { return new(GoawayFrame) },
+	TypeConnectToFrame:    func() Frame { return new(ConnectToFrame) },
 }
 
 // NewFrame creates a new frame from Type.

--- a/core/frame/frame.go
+++ b/core/frame/frame.go
@@ -90,7 +90,7 @@ type GoawayFrame struct {
 // Type returns the type of GoawayFrame.
 func (f *GoawayFrame) Type() Type { return TypeGoawayFrame }
 
-// ConnectToFrame is is used by server notify client to connect to a new endpoint.
+// ConnectToFrame is is used by server to notify client to connect a new endpoint.
 type ConnectToFrame struct {
 	// Endpoint is the new endpoint that will be connected by client.
 	Endpoint string

--- a/pkg/frame-codec/y3codec/codec.go
+++ b/pkg/frame-codec/y3codec/codec.go
@@ -49,6 +49,8 @@ func (c *y3codec) Encode(f frame.Frame) ([]byte, error) {
 		return encodeDataFrame(ff)
 	case *frame.GoawayFrame:
 		return encodeGoawayFrame(ff)
+	case *frame.ConnectToFrame:
+		return encodeConnectToFrame(ff)
 	default:
 		return nil, ErrUnknownFrame
 	}
@@ -66,6 +68,8 @@ func (c *y3codec) Decode(data []byte, f frame.Frame) error {
 		return decodeDataFrame(data, ff)
 	case *frame.GoawayFrame:
 		return decodeGoawayFrame(data, ff)
+	case *frame.ConnectToFrame:
+		return decodeConnectToFrame(data, ff)
 	default:
 		return ErrUnknownFrame
 	}

--- a/pkg/frame-codec/y3codec/codec_test.go
+++ b/pkg/frame-codec/y3codec/codec_test.go
@@ -120,6 +120,19 @@ func TestCodec(t *testing.T) {
 			},
 		},
 		{
+			name: "ConnectToFrame",
+			args: args{
+				newF: new(frame.ConnectToFrame),
+				dataF: &frame.ConnectToFrame{
+					Endpoint: "11.11.11.11:8080",
+				},
+				data: []byte{
+					0xbe, 0x12, 0x1, 0x10, 0x31, 0x31, 0x2e, 0x31, 0x31, 0x2e,
+					0x31, 0x31, 0x2e, 0x31, 0x31, 0x3a, 0x38, 0x30, 0x38, 0x30,
+				},
+			},
+		},
+		{
 			name: "error",
 			args: args{
 				newF:      nil,

--- a/pkg/frame-codec/y3codec/connect_to_frame.go
+++ b/pkg/frame-codec/y3codec/connect_to_frame.go
@@ -1,0 +1,42 @@
+package y3codec
+
+import (
+	"github.com/yomorun/y3"
+	frame "github.com/yomorun/yomo/core/frame"
+)
+
+// encodeConnectToFrame encodes ConnectToFrame to Y3 encoded bytes.
+func encodeConnectToFrame(f *frame.ConnectToFrame) ([]byte, error) {
+	// endpoint
+	endpointBlock := y3.NewPrimitivePacketEncoder(tagConnectToEndpoint)
+	endpointBlock.SetStringValue(f.Endpoint)
+	// frame
+	ff := y3.NewNodePacketEncoder(byte(f.Type()))
+	ff.AddPrimitivePacket(endpointBlock)
+
+	return ff.Encode(), nil
+}
+
+// decodeConnectToFrame decodes Y3 encoded bytes to ConnectToFrame.
+func decodeConnectToFrame(data []byte, f *frame.ConnectToFrame) error {
+	node := y3.NodePacket{}
+	_, err := y3.DecodeToNodePacket(data, &node)
+	if err != nil {
+		return err
+	}
+
+	// endpoint
+	if endpointBlock, ok := node.PrimitivePackets[tagConnectToEndpoint]; ok {
+		endpoint, err := endpointBlock.ToUTF8String()
+		if err != nil {
+			return err
+		}
+		f.Endpoint = endpoint
+	}
+
+	return nil
+}
+
+var (
+	tagConnectToEndpoint byte = 0x01
+)


### PR DESCRIPTION
# Description

Adding `ConnectToFrame` and Its y3 codec implement, The `ConnectToFrame` is used by server to notify client to connect a new endpoint.

```go
// ConnectToFrame is is used by server notify client to connect to a new endpoint.
type ConnectToFrame struct {
	// Endpoint is the new endpoint that will be connected by client.
	Endpoint string
}
```