### PR TITLE
feat: add cron handler for sfn

### DIFF
--- a/core/handler_type.go
+++ b/core/handler_type.go
@@ -5,6 +5,8 @@ import (
 	"github.com/yomorun/yomo/serverless"
 )
 
+type CronHandler func(ctx serverless.CronContext)
+
 // AsyncHandler is the request-response mode (asnyc)
 type AsyncHandler func(ctx serverless.Context)
 

--- a/core/handler_type.go
+++ b/core/handler_type.go
@@ -5,9 +5,10 @@ import (
 	"github.com/yomorun/yomo/serverless"
 )
 
+// CronHandler is the cron mode.
 type CronHandler func(ctx serverless.CronContext)
 
-// AsyncHandler is the request-response mode (asnyc)
+// AsyncHandler is the request-response mode (asnyc).
 type AsyncHandler func(ctx serverless.Context)
 
 // PipeHandler is the bidirectional stream mode (blocking).

--- a/core/metadata.go
+++ b/core/metadata.go
@@ -36,10 +36,31 @@ func SetMetadataTarget(m metadata.M, target string) {
 	m.Set(metadata.TargetKey, target)
 }
 
-// SourceMetadata generates source metadata with trace information.
-func SourceMetadata(
+// SourceMetadata generates initial source metadata with trace information.
+func InitialSourceMetadata(
 	sourceID, tid string,
-	spanName string, // the span name usually is the source name.
+	tracerName string,
+	tp oteltrace.TracerProvider, logger *slog.Logger,
+) (metadata.M, func()) {
+	return initialMetadata(sourceID, tid, "Source", tracerName, tp, logger)
+}
+
+// InitialSfnMetadata generates initial sfn metadata with trace information.
+func InitialSfnMetadata(
+	sourceID, tid string,
+	tracerName string,
+	tp oteltrace.TracerProvider, logger *slog.Logger,
+) (metadata.M, func()) {
+	return initialMetadata(sourceID, tid, "StreamFunction", tracerName, tp, logger)
+}
+
+// initialMetadata builds a metadata with trace information.
+// the tracer name is `Source` or `StreamFunction`.
+// span name typically corresponds to the source or sfn name.
+func initialMetadata(
+	sourceID, tid string,
+	tracerName string,
+	spanName string,
 	tp oteltrace.TracerProvider, logger *slog.Logger,
 ) (metadata.M, func()) {
 	var (

--- a/core/metadata.go
+++ b/core/metadata.go
@@ -36,27 +36,29 @@ func SetMetadataTarget(m metadata.M, target string) {
 	m.Set(metadata.TargetKey, target)
 }
 
-// SourceMetadata generates initial source metadata with trace information.
+// InitialSourceMetadata generates initial source metadata with trace information.
+// the span name typically corresponds to the source's name.
 func InitialSourceMetadata(
 	sourceID, tid string,
-	tracerName string,
+	spanName string,
 	tp oteltrace.TracerProvider, logger *slog.Logger,
 ) (metadata.M, func()) {
-	return initialMetadata(sourceID, tid, "Source", tracerName, tp, logger)
+	return initialMetadata(sourceID, tid, "Source", spanName, tp, logger)
 }
 
 // InitialSfnMetadata generates initial sfn metadata with trace information.
+// the span name typically corresponds to the sfn's name.
 func InitialSfnMetadata(
 	sourceID, tid string,
-	tracerName string,
+	spanName string,
 	tp oteltrace.TracerProvider, logger *slog.Logger,
 ) (metadata.M, func()) {
-	return initialMetadata(sourceID, tid, "StreamFunction", tracerName, tp, logger)
+	return initialMetadata(sourceID, tid, "StreamFunction", spanName, tp, logger)
 }
 
 // initialMetadata builds a metadata with trace information.
 // the tracer name is `Source` or `StreamFunction`.
-// span name typically corresponds to the source or sfn name.
+// span name typically corresponds to the source's name or sfn's name.
 func initialMetadata(
 	sourceID, tid string,
 	tracerName string,

--- a/core/serverless/context_http.go
+++ b/core/serverless/context_http.go
@@ -4,7 +4,12 @@ import (
 	"github.com/yomorun/yomo/serverless"
 )
 
-// HTTP is the interface for HTTP request, but it is not implemented in the server side
+// HTTP is the interface of Context for HTTP request, but it is not implemented in the server side
 func (c *Context) HTTP() serverless.HTTP {
+	return nil
+}
+
+// HTTP is the interface of CronContext for HTTP request, but it is not implemented in the server side
+func (c *CronContext) HTTP() serverless.HTTP {
 	return nil
 }

--- a/core/serverless/cron_context.go
+++ b/core/serverless/cron_context.go
@@ -1,0 +1,64 @@
+package serverless
+
+import (
+	"github.com/yomorun/yomo/core/frame"
+	"github.com/yomorun/yomo/core/metadata"
+)
+
+// CronContext sfn cron handler context
+type CronContext struct {
+	writer frame.Writer
+	md     metadata.M
+}
+
+// NewCronContext creates a new serverless CronContext
+func NewCronContext(writer frame.Writer, md metadata.M) *CronContext {
+	return &CronContext{
+		writer: writer,
+		md:     md,
+	}
+}
+
+// Write writes the data to next sfn instance.
+func (c *CronContext) Write(tag uint32, data []byte) error {
+	if data == nil {
+		return nil
+	}
+
+	mdBytes, err := c.md.Encode()
+	if err != nil {
+		return err
+	}
+
+	dataFrame := &frame.DataFrame{
+		Tag:      tag,
+		Metadata: mdBytes,
+		Payload:  data,
+	}
+
+	return c.writer.WriteFrame(dataFrame)
+}
+
+// WriteWithTarget writes the data to next sfn instance with specified target.
+func (c *CronContext) WriteWithTarget(tag uint32, data []byte, target string) error {
+	if data == nil {
+		return nil
+	}
+
+	if target != "" {
+		c.md.Set(metadata.TargetKey, target)
+	}
+
+	mdBytes, err := c.md.Encode()
+	if err != nil {
+		return err
+	}
+
+	dataFrame := &frame.DataFrame{
+		Tag:      tag,
+		Metadata: mdBytes,
+		Payload:  data,
+	}
+
+	return c.writer.WriteFrame(dataFrame)
+}

--- a/core/serverless/cron_context.go
+++ b/core/serverless/cron_context.go
@@ -7,15 +7,19 @@ import (
 
 // CronContext sfn cron handler context
 type CronContext struct {
-	writer frame.Writer
-	md     metadata.M
+	writer  frame.Writer
+	md      metadata.M
+	mdBytes []byte
 }
 
 // NewCronContext creates a new serverless CronContext
 func NewCronContext(writer frame.Writer, md metadata.M) *CronContext {
+	mdBytes, _ := md.Encode()
+
 	return &CronContext{
-		writer: writer,
-		md:     md,
+		writer:  writer,
+		md:      md,
+		mdBytes: mdBytes,
 	}
 }
 
@@ -25,14 +29,9 @@ func (c *CronContext) Write(tag uint32, data []byte) error {
 		return nil
 	}
 
-	mdBytes, err := c.md.Encode()
-	if err != nil {
-		return err
-	}
-
 	dataFrame := &frame.DataFrame{
 		Tag:      tag,
-		Metadata: mdBytes,
+		Metadata: c.mdBytes,
 		Payload:  data,
 	}
 

--- a/core/serverless/cron_context.go
+++ b/core/serverless/cron_context.go
@@ -44,9 +44,11 @@ func (c *CronContext) WriteWithTarget(tag uint32, data []byte, target string) er
 		return nil
 	}
 
-	if target != "" {
-		c.md.Set(metadata.TargetKey, target)
+	if target == "" {
+		return c.Write(tag, data)
 	}
+
+	c.md.Set(metadata.TargetKey, target)
 
 	mdBytes, err := c.md.Encode()
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/matoous/go-nanoid/v2 v2.0.0
 	github.com/quic-go/quic-go v0.40.1
 	github.com/reactivex/rxgo/v2 v2.5.0
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/second-state/WasmEdge-go v0.13.4
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -134,6 +134,8 @@ github.com/quic-go/quic-go v0.40.1 h1:X3AGzUNFs0jVuO3esAGnTfvdgvL4fq655WaOi1snv1
 github.com/quic-go/quic-go v0.40.1/go.mod h1:PeN7kuVJ4xZbxSv/4OX6S1USOX8MJvydwpTx31vx60c=
 github.com/reactivex/rxgo/v2 v2.5.0 h1:FhPgHwX9vKdNQB2gq9EPt+EKk9QrrzoeztGbEEnZam4=
 github.com/reactivex/rxgo/v2 v2.5.0/go.mod h1:bs4fVZxcb5ZckLIOeIeVH942yunJLWDABWGbrHAW+qU=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/serverless/context.go
+++ b/serverless/context.go
@@ -15,6 +15,16 @@ type Context interface {
 	WriteWithTarget(tag uint32, data []byte, target string) error
 }
 
+// CronContext sfn corn handler context
+type CronContext interface {
+	// Write writes data
+	Write(tag uint32, data []byte) error
+	// HTTP http interface
+	HTTP() HTTP
+	// WriteWithTarget writes data to sfn instance with specified target
+	WriteWithTarget(tag uint32, data []byte, target string) error
+}
+
 // HTTP http interface
 type HTTP interface {
 	Send(req *HTTPRequest) (*HTTPResponse, error)

--- a/sfn.go
+++ b/sfn.go
@@ -119,7 +119,7 @@ func (s *streamFunction) SetPipeHandler(fn core.PipeHandler) error {
 }
 
 // Connect create a connection to the zipper, when data arrvied, the data will be passed to the
-// handler which setted by SetHandler method.
+// handler set by SetHandler method.
 func (s *streamFunction) Connect() error {
 	hasCron := s.cronFn != nil && s.cronSpec != ""
 	if hasCron {

--- a/source.go
+++ b/source.go
@@ -71,7 +71,7 @@ func (s *yomoSource) Connect() error {
 
 // Write writes data with specified tag.
 func (s *yomoSource) Write(tag uint32, data []byte) error {
-	md, deferFunc := core.SourceMetadata(s.client.ClientID(), id.New(), s.name, s.client.TracerProvider(), s.client.Logger)
+	md, deferFunc := core.InitialSourceMetadata(s.client.ClientID(), id.New(), s.name, s.client.TracerProvider(), s.client.Logger)
 	defer deferFunc()
 
 	mdBytes, err := md.Encode()
@@ -93,7 +93,7 @@ func (s *yomoSource) WriteWithTarget(tag uint32, data []byte, target string) err
 	if data == nil {
 		return nil
 	}
-	md, deferFunc := core.SourceMetadata(s.client.ClientID(), id.New(), s.name, s.client.TracerProvider(), s.client.Logger)
+	md, deferFunc := core.InitialSourceMetadata(s.client.ClientID(), id.New(), s.name, s.client.TracerProvider(), s.client.Logger)
 	defer deferFunc()
 
 	if target != "" {


### PR DESCRIPTION
# Description

Adding `SetCronHandler` api for sfn, call it like below:
```go
sfn.SetCronHandler("@every 1s", func(ctx serverless.CronContext) {
    ctx.Write(0x22, []byte("message from cron sfn"))
    ctx.WriteWithTarget(0x22, []byte("message from cron sfn"),  "target-id")
})
```
