### PR TITLE
refactor: azure openai provider configuration follows azure-sdk

### DIFF
--- a/cli/serve.go
+++ b/cli/serve.go
@@ -125,12 +125,14 @@ func registerAIProvider(aiConfig *ai.Config) {
 		if name == "azopenai" {
 			apiKey := provider["api_key"]
 			apiEndpoint := provider["api_endpoint"]
+			deploymentID := provider["deployment_id"]
+			apiVersion := provider["api_version"]
 			if apiKey == "" || apiEndpoint == "" {
 				// log.InfoStatusEvent(os.Stdout, "register Azure OpenAI provider used by New()")
 				ai.RegisterProvider(azopenai.New())
 			} else {
 				// log.InfoStatusEvent(os.Stdout, "register Azure OpenAI provider used by NewAzureOpenAIProvider()")
-				ai.RegisterProvider(azopenai.NewAzureOpenAIProvider(apiKey, apiEndpoint))
+				ai.RegisterProvider(azopenai.NewAzureOpenAIProvider(apiKey, apiEndpoint, deploymentID, apiVersion))
 			}
 		}
 		// TODO: register other providers

--- a/example/10-ai/zipper.yaml
+++ b/example/10-ai/zipper.yaml
@@ -14,13 +14,14 @@ bridge:
 
     providers:
       azopenai:
-        api_key: 
         api_endpoint: 
+        deployment_id: 
+        api_key: 
+        api_version: 
 
       openai:
         api_key:
         api_endpoint:
 
-      huggingface:
-        model:
-
+      gemini:
+        api_key:

--- a/pkg/bridge/ai/provider/azopenai/provider.go
+++ b/pkg/bridge/ai/provider/azopenai/provider.go
@@ -68,8 +68,10 @@ type RespUsage struct {
 
 // AzureOpenAIProvider is the provider for Azure OpenAI
 type AzureOpenAIProvider struct {
-	APIKey      string
-	APIEndpoint string
+	APIKey       string
+	APIEndpoint  string
+	DeploymentID string
+	APIVersion   string
 }
 
 type connectedFn struct {
@@ -83,10 +85,12 @@ func init() {
 }
 
 // NewAzureOpenAIProvider creates a new AzureOpenAIProvider
-func NewAzureOpenAIProvider(apiKey string, apiEndpoint string) *AzureOpenAIProvider {
+func NewAzureOpenAIProvider(apiKey string, apiEndpoint string, deploymentID string, apiVersion string) *AzureOpenAIProvider {
 	return &AzureOpenAIProvider{
-		APIKey:      apiKey,
-		APIEndpoint: apiEndpoint,
+		APIKey:       apiKey,
+		APIEndpoint:  apiEndpoint,
+		DeploymentID: deploymentID,
+		APIVersion:   apiVersion,
 	}
 }
 
@@ -142,7 +146,8 @@ func (p *AzureOpenAIProvider) GetChatCompletions(userInstruction string) (*ai.In
 		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", p.APIEndpoint, bytes.NewBuffer(jsonBody))
+	url := fmt.Sprintf("%s/openai/deployments/%s/chat/completions?api-version=%s", p.APIEndpoint, p.DeploymentID, p.APIVersion)
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonBody))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
```yaml
providers:
      azopenai:
        api_endpoint: ## e.g. https://xxx.openai.azure.com
        deployment_id: 
        api_key: 
        api_version: ## e.g. 2023-12-01-preview
```