### PR TITLE
fix: service system prompt init as an empty string

### DIFF
--- a/pkg/bridge/ai/service.go
+++ b/pkg/bridge/ai/service.go
@@ -75,6 +75,9 @@ func newService(credential string, zipperAddr string, aiProvider LLMProvider, ex
 		LLMProvider:  aiProvider,
 		sfnCallCache: make(map[string]*sfnAsyncCall),
 	}
+
+	s.SetSystemPrompt("")
+
 	// metadata
 	if exFn == nil {
 		s.Metadata = metadata.M{}


### PR DESCRIPTION
# Description

fix bug below:
![image](https://github.com/yomorun/yomo/assets/17943570/3f6287e0-69a3-45e2-a30e-0f9184e343ec)
