### PR TITLE
feat(ai-bridge): handle llm-sfn return nothing or multiple results returned

### DIFF
--- a/core/serverless/context_llm.go
+++ b/core/serverless/context_llm.go
@@ -34,6 +34,7 @@ func (c *Context) WriteLLMResult(result string) error {
 	if err != nil {
 		return err
 	}
+	c.data = buf
 	return c.Write(ai.ReducerTag, buf)
 }
 

--- a/core/serverless/context_llm.go
+++ b/core/serverless/context_llm.go
@@ -9,8 +9,7 @@ import (
 
 // ReadLLMArguments reads LLM function arguments
 func (c *Context) ReadLLMArguments(args any) error {
-	fnCall := &ai.FunctionCall{}
-	err := fnCall.FromBytes(c.data)
+	fnCall, err := c.LLMFunctionCall()
 	if err != nil {
 		return err
 	}

--- a/core/serverless/context_llm.go
+++ b/core/serverless/context_llm.go
@@ -27,6 +27,9 @@ func (c *Context) WriteLLMResult(result string) error {
 	if c.fnCall == nil {
 		return errors.New("no function call, can't write result")
 	}
+	if c.fnCall.IsOK && c.fnCall.Result != "" {
+		return errors.New("LLM function can only be called once")
+	}
 	// function call
 	c.fnCall.IsOK = true
 	c.fnCall.Result = result

--- a/pkg/bridge/ai/service.go
+++ b/pkg/bridge/ai/service.go
@@ -427,7 +427,7 @@ func (s *Service) GetChatCompletions(ctx context.Context, req openai.ChatComplet
 		}
 		promptUsage = resp.Usage.PromptTokens
 		completionUsage = resp.Usage.CompletionTokens
-		totalUsage = resp.Usage.CompletionTokens
+		totalUsage = resp.Usage.TotalTokens
 
 		ylog.Debug(" #1 first call", "response", fmt.Sprintf("%+v", resp))
 		// it is a function call

--- a/serverless/mock/mock_context.go
+++ b/serverless/mock/mock_context.go
@@ -104,21 +104,20 @@ func (c *MockContext) WriteLLMResult(result string) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	var (
-		buf    []byte
-		fnCall = &ai.FunctionCall{}
-	)
-
-	err := fnCall.FromBytes(c.data)
-	if err == nil {
-		c.fnCall = fnCall
-		// function call
-		c.fnCall.IsOK = true
-		c.fnCall.Result = result
-		buf, err = c.fnCall.Bytes()
+	if c.fnCall == nil {
+		fnCall, err := c.LLMFunctionCall()
 		if err != nil {
 			return err
 		}
+		c.fnCall = fnCall
+	}
+
+	// function call
+	c.fnCall.IsOK = true
+	c.fnCall.Result = result
+	buf, err := c.fnCall.Bytes()
+	if err != nil {
+		return err
 	}
 
 	c.wrSlice = append(c.wrSlice, WriteRecord{

--- a/serverless/mock/mock_context.go
+++ b/serverless/mock/mock_context.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/yomorun/yomo/ai"
 	"github.com/yomorun/yomo/serverless"
-	"github.com/yomorun/yomo/serverless/guest"
 )
 
 var _ serverless.Context = (*MockContext)(nil)
@@ -55,7 +54,7 @@ func (c *MockContext) Metadata(_ string) (string, bool) {
 
 // HTTP returns the HTTP interface.H
 func (m *MockContext) HTTP() serverless.HTTP {
-	return &guest.GuestHTTP{}
+	panic("not implemented, to use `net/http` package")
 }
 
 // Write writes the data with the given tag.
@@ -105,15 +104,21 @@ func (c *MockContext) WriteLLMResult(result string) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if c.fnCall == nil {
-		return errors.New("no function call, can't write result")
-	}
-	// function call
-	c.fnCall.IsOK = true
-	c.fnCall.Result = result
-	buf, err := c.fnCall.Bytes()
-	if err != nil {
-		return err
+	var (
+		buf    []byte
+		fnCall = &ai.FunctionCall{}
+	)
+
+	err := fnCall.FromBytes(c.data)
+	if err == nil {
+		c.fnCall = fnCall
+		// function call
+		c.fnCall.IsOK = true
+		c.fnCall.Result = result
+		buf, err = c.fnCall.Bytes()
+		if err != nil {
+			return err
+		}
 	}
 
 	c.wrSlice = append(c.wrSlice, WriteRecord{

--- a/serverless/mock/mock_context_test.go
+++ b/serverless/mock/mock_context_test.go
@@ -89,3 +89,14 @@ func TestWriteLLMResult(t *testing.T) {
 	assert.Equal(t, ai.ReducerTag, res[0].Tag)
 	assert.Equal(t, jsonStrWithResult("test result"), string(res[0].Data))
 }
+
+func TestWriteLLMResultWithoutRead(t *testing.T) {
+	ctx := NewMockContext([]byte(jsonStr), 0x10)
+	// write
+	err := ctx.WriteLLMResult("test result")
+	assert.NoError(t, err)
+
+	res := ctx.RecordsWritten()
+	assert.Equal(t, ai.ReducerTag, res[0].Tag)
+	assert.Equal(t, jsonStrWithResult("test result"), string(res[0].Data))
+}

--- a/sfn_test.go
+++ b/sfn_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/yomorun/yomo/core/frame"
 	"github.com/yomorun/yomo/core/ylog"
 	"github.com/yomorun/yomo/serverless"
-	"github.com/yomorun/yomo/serverless/mock"
 )
 
 var (
@@ -145,54 +144,4 @@ func TestSfnCron(t *testing.T) {
 	assert.Nil(t, err)
 
 	sfn.Wait()
-}
-
-func TestPatchCtxLLMFunctionCall(t *testing.T) {
-	type args struct {
-		serverlessCtx serverless.Context
-	}
-	tests := []struct {
-		name        string
-		args        args
-		want        string
-		wantWritten bool
-	}{
-		{
-			name: "function call ok",
-			args: args{
-				serverlessCtx: mock.NewMockContext([]byte(`{"tid":"y8P73i-xbOr4RX2wxKd6x4URrPJLq-L1","req_id":"HHZuifDG7O41bviu","arguments":"hello yomo","tool_call_id":"call_xX0uhdsGZjPqx0hpM5JjbbjG","function_name":"say_hi","is_ok":true}`), 0x21),
-			},
-			want:        "",
-			wantWritten: false,
-		},
-		{
-			name: "function call not ok",
-			args: args{
-				serverlessCtx: mock.NewMockContext([]byte(`{"tid":"y8P73i-xbOr4RX2wxKd6x4URrPJLq-L1","req_id":"HHZuifDG7O41bviu","arguments":"","tool_call_id":"call_xX0uhdsGZjPqx0hpM5JjbbjG","function_name":"say_hi","is_ok":false}`), 0x21),
-			},
-			want:        `{"tid":"y8P73i-xbOr4RX2wxKd6x4URrPJLq-L1","req_id":"HHZuifDG7O41bviu","result":"this function calling do not return any message, you should ignore this.","arguments":"","tool_call_id":"call_xX0uhdsGZjPqx0hpM5JjbbjG","function_name":"say_hi","is_ok":true}`,
-			wantWritten: true,
-		},
-
-		{
-			name: "not a function call",
-			args: args{
-				serverlessCtx: mock.NewMockContext([]byte(`hello yomo`), 0x21),
-			},
-			want:        "",
-			wantWritten: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctx := tt.args.serverlessCtx
-			patchCtxLLMFunctionCall(ctx)
-
-			records := ctx.(*mock.MockContext).RecordsWritten()
-			assert.Equal(t, tt.wantWritten, len(records) != 0)
-			if tt.wantWritten {
-				assert.Equal(t, tt.want, string(records[0].Data))
-			}
-		})
-	}
 }


### PR DESCRIPTION
- Multiple `ctx.WriteLLMResult()` shall be ignored with a warning log