### PR TITLE
feat(llm-bridge): add ollama provider with mistral model support

### DIFF
--- a/cli/serve.go
+++ b/cli/serve.go
@@ -141,7 +141,7 @@ func registerAIProvider(aiConfig *ai.Config) error {
 				provider["model"],
 			))
 		case "ollama":
-			ai.RegisterProvider(ollama.NewProvider(provider["endpoint"]))
+			ai.RegisterProvider(ollama.NewProvider(provider["api_endpoint"]))
 		default:
 			log.WarningStatusEvent(os.Stdout, "unknown provider: %s", name)
 		}

--- a/cli/serve.go
+++ b/cli/serve.go
@@ -30,6 +30,7 @@ import (
 	"github.com/yomorun/yomo/pkg/bridge/ai/provider/azopenai"
 	"github.com/yomorun/yomo/pkg/bridge/ai/provider/cfazure"
 	"github.com/yomorun/yomo/pkg/bridge/ai/provider/cfopenai"
+	"github.com/yomorun/yomo/pkg/bridge/ai/provider/ollama"
 	"github.com/yomorun/yomo/pkg/bridge/ai/provider/openai"
 )
 
@@ -139,6 +140,8 @@ func registerAIProvider(aiConfig *ai.Config) error {
 				provider["api_key"],
 				provider["model"],
 			))
+		case "ollama":
+			ai.RegisterProvider(ollama.NewProvider(provider["endpoint"]))
 		default:
 			log.WarningStatusEvent(os.Stdout, "unknown provider: %s", name)
 		}

--- a/pkg/bridge/ai/provider/ollama/Readme.md
+++ b/pkg/bridge/ai/provider/ollama/Readme.md
@@ -1,0 +1,42 @@
+# Ollama LLM inference provider
+
+This provider makes it possible to build up a YoMo AI architecture with fully open-source dependencies.
+
+1. Install Ollama
+
+Follow the Ollama doc: https://github.com/ollama/ollama?tab=readme-ov-file#ollama
+
+2. Run the Mistral model
+
+Notice that only the Mistral v0.3+ models are supported currently.
+
+```sh
+ollama run mistral:7b
+```
+
+3. Start YoMo Zipper
+
+By default, ollama server will be listening at the port 11434. Then the config file may be:
+
+```yml
+name: Service
+host: 0.0.0.0
+port: 9000
+
+bridge:
+  ai:
+    server:
+      addr: "localhost:8000"
+      provider: ollama
+    providers:
+      ollama:
+        endpoint: "http://localhost:11434/"
+```
+
+```sh
+yomo serve -c config.yml
+```
+
+4. Start YoMo serverless function
+
+[example](../../../../../example/10-ai/README.md)

--- a/pkg/bridge/ai/provider/ollama/Readme.md
+++ b/pkg/bridge/ai/provider/ollama/Readme.md
@@ -1,4 +1,4 @@
-# Ollama LLM inference provider
+# Ollama LLM Inference Provider
 
 Build up your YoMo AI architecture with fully open-source dependencies.
 

--- a/pkg/bridge/ai/provider/ollama/Readme.md
+++ b/pkg/bridge/ai/provider/ollama/Readme.md
@@ -1,12 +1,14 @@
 # Ollama LLM inference provider
 
-This provider makes it possible to build up a YoMo AI architecture with fully open-source dependencies.
+Build up your YoMo AI architecture with fully open-source dependencies.
 
-1. Install Ollama
+## 1. Install Ollama
 
-Follow the Ollama doc: https://github.com/ollama/ollama?tab=readme-ov-file#ollama
+Follow the Ollama doc:
 
-2. Run the Mistral model
+<https://github.com/ollama/ollama?tab=readme-ov-file#ollama>
+
+## 2. Run the Mistral model
 
 Notice that only the Mistral v0.3+ models are supported currently.
 
@@ -14,9 +16,11 @@ Notice that only the Mistral v0.3+ models are supported currently.
 ollama run mistral:7b
 ```
 
-3. Start YoMo Zipper
+## 3. Start YoMo Zipper
 
-By default, ollama server will be listening at the port 11434. Then the config file may be:
+By default, ollama server will be listening at the port 11434.
+
+Then the config file could be:
 
 ```yml
 name: Service
@@ -30,13 +34,13 @@ bridge:
       provider: ollama
     providers:
       ollama:
-        endpoint: "http://localhost:11434/"
+        api_endpoint: "http://localhost:11434/"
 ```
 
 ```sh
 yomo serve -c config.yml
 ```
 
-4. Start YoMo serverless function
+## 4. Start YoMo serverless function
 
 [example](../../../../../example/10-ai/README.md)

--- a/pkg/bridge/ai/provider/ollama/provider.go
+++ b/pkg/bridge/ai/provider/ollama/provider.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"text/template"
 	"time"
@@ -58,6 +59,10 @@ const (
 )
 
 func makeOllamaRequestBody(req openai.ChatCompletionRequest) (io.Reader, error) {
+	if req.Model == "" {
+		req.Model = "mistral"
+	}
+
 	if !strings.HasPrefix(req.Model, "mistral") {
 		return nil, errors.New("currently only Mistral models are supported, see https://ollama.com/library/mistral")
 	}
@@ -334,5 +339,13 @@ func (p *Provider) Name() string {
 
 // NewProvider creates a new OllamaProvider
 func NewProvider(endpoint string) *Provider {
+	if endpoint == "" {
+		v, ok := os.LookupEnv("OLLAMA_API_ENDPOINT")
+		if ok {
+			endpoint = v
+		} else {
+			endpoint = "http://localhost:11434/"
+		}
+	}
 	return &Provider{endpoint}
 }

--- a/pkg/bridge/ai/provider/ollama/provider.go
+++ b/pkg/bridge/ai/provider/ollama/provider.go
@@ -1,0 +1,200 @@
+package ollama
+
+import (
+	"bytes"
+	"context"
+	_ "embed"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"text/template"
+	"time"
+
+	openai "github.com/sashabaranov/go-openai"
+	"github.com/yomorun/yomo/core/metadata"
+	"github.com/yomorun/yomo/core/ylog"
+	"github.com/yomorun/yomo/pkg/bridge/ai"
+	"github.com/yomorun/yomo/pkg/id"
+)
+
+// Provider is the provider for Ollama
+type Provider struct {
+	Endpoint string
+}
+
+type ollamaRequest struct {
+	Model  string `json:"model"`
+	Prompt string `json:"prompt"`
+	Raw    bool   `json:"raw"`
+	Stream bool   `json:"stream"`
+}
+
+type ollamaResponse struct {
+	Response string `json:"response"`
+}
+
+type templateRequest struct {
+	Tools  string
+	System string
+	Prompt string
+}
+
+type mistralFunction struct {
+	Name      string         `json:"name"`
+	Arguments map[string]any `json:"arguments"`
+}
+
+const (
+	defaultSystem = "You are a very helpful assistant. Your job is to choose the best possible action to solve the user question or task."
+
+	systemToolExtra = "If the question of the user matched the description of a tool, the tool will be called, and only the function description JSON object should be returned. Don't make assumptions about what values to plug into functions. Ask for clarification if a user request is ambiguous."
+
+	mistralTmpl = "[AVAILABLE_TOOLS] {{.Tools}} [/AVAILABLE_TOOLS][INST] {{ if .System }}{{ .System }} {{ end }}{{ .Prompt }} [/INST]"
+)
+
+// GetChatCompletions implements ai.LLMProvider.
+func (p *Provider) GetChatCompletions(ctx context.Context, req openai.ChatCompletionRequest, _ metadata.M) (openai.ChatCompletionResponse, error) {
+	res := openai.ChatCompletionResponse{
+		ID:      "chatcmpl-" + id.New(29),
+		Model:   req.Model,
+		Created: time.Now().Unix(),
+		Choices: []openai.ChatCompletionChoice{
+			{
+				Index: 0,
+				Message: openai.ChatCompletionMessage{
+					Role:    "assitant",
+					Content: "error occured during inference period",
+				},
+				FinishReason: "stop",
+			},
+		},
+		Usage: openai.Usage{}, // todo
+	}
+
+	if !strings.HasPrefix(req.Model, "mistral") {
+		return res, errors.New("currently only Mistral models are supported, see https://ollama.com/library/mistral")
+	}
+
+	t := &templateRequest{
+		System: defaultSystem,
+		Tools:  "[]",
+	}
+	for _, msg := range req.Messages {
+		switch strings.ToLower(msg.Role) {
+		case "system":
+			t.System = msg.Content
+		case "user":
+			t.Prompt += msg.Content
+		case "tool":
+			t.Prompt += msg.Content
+		}
+	}
+
+	if req.Tools != nil {
+		t.System += systemToolExtra
+
+		tools, err := json.Marshal(req.Tools)
+		if err != nil {
+			return res, err
+		}
+		t.Tools = string(tools)
+	}
+
+	ylog.Debug("ollama chat request", "model", req.Model, "system", t.System, "prompt", t.Prompt, "tools", t.Tools)
+
+	tmpl, err := template.New("ollama").Parse(mistralTmpl)
+	if err != nil {
+		return res, err
+	}
+
+	prompt := bytes.NewBufferString("")
+	err = tmpl.Execute(prompt, t)
+	if err != nil {
+		return res, err
+	}
+
+	body, err := json.Marshal(&ollamaRequest{
+		Model:  req.Model,
+		Prompt: prompt.String(),
+		Raw:    true,
+		Stream: req.Stream,
+	})
+	if err != nil {
+		return res, err
+	}
+
+	urlPath, err := url.JoinPath(p.Endpoint, "api/generate")
+	if err != nil {
+		return res, err
+	}
+
+	resp, err := http.Post(urlPath, "application/json", bytes.NewBuffer(body))
+	if err != nil {
+		return res, err
+	}
+	defer resp.Body.Close()
+
+	body, err = io.ReadAll(resp.Body)
+	if err != nil {
+		return res, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return res, fmt.Errorf("ollama inference error: %s", resp.Status)
+	}
+
+	ylog.Debug("ollama chat response", "body", string(body))
+
+	var o ollamaResponse
+	err = json.Unmarshal(body, &o)
+	if err != nil {
+		return res, err
+	}
+
+	if o.Response != "" {
+		o.Response = strings.TrimPrefix(o.Response, "[TOOL_CALLS]")
+
+		res.Choices[0].Message.Content = o.Response
+
+		var functions []mistralFunction
+		err = json.Unmarshal([]byte(o.Response), &functions)
+		if err == nil {
+			res.Choices[0].FinishReason = "tool_calls"
+			res.Choices[0].Message.ToolCalls = make([]openai.ToolCall, 0)
+			for _, f := range functions {
+				arguments, _ := json.Marshal(f.Arguments)
+				res.Choices[0].Message.ToolCalls = append(
+					res.Choices[0].Message.ToolCalls, openai.ToolCall{
+						ID:   id.New(),
+						Type: openai.ToolTypeFunction,
+						Function: openai.FunctionCall{
+							Name:      f.Name,
+							Arguments: string(arguments),
+						},
+					},
+				)
+			}
+		}
+	}
+
+	return res, nil
+}
+
+// GetChatCompletionsStream implements ai.LLMProvider.
+func (p *Provider) GetChatCompletionsStream(ctx context.Context, req openai.ChatCompletionRequest, _ metadata.M) (ai.ResponseRecver, error) {
+	panic("unimplemented")
+}
+
+// Name implements ai.LLMProvider.
+func (p *Provider) Name() string {
+	return "ollama"
+}
+
+// NewProvider creates a new OllamaProvider
+func NewProvider(endpoint string) *Provider {
+	return &Provider{endpoint}
+}

--- a/pkg/bridge/ai/provider/ollama/provider.go
+++ b/pkg/bridge/ai/provider/ollama/provider.go
@@ -35,6 +35,7 @@ type ollamaRequest struct {
 
 type ollamaResponse struct {
 	Response string `json:"response"`
+	Done     bool   `json:"done"`
 }
 
 type templateRequest struct {
@@ -53,8 +54,90 @@ const (
 
 	systemToolExtra = "If the question of the user matched the description of a tool, the tool will be called, and only the function description JSON object should be returned. Don't make assumptions about what values to plug into functions. Ask for clarification if a user request is ambiguous."
 
-	mistralTmpl = "[AVAILABLE_TOOLS] {{.Tools}} [/AVAILABLE_TOOLS][INST] {{ if .System }}{{ .System }} {{ end }}{{ .Prompt }} [/INST]"
+	mistralTmpl = "{{ if .Tools }}[AVAILABLE_TOOLS] {{.Tools}} [/AVAILABLE_TOOLS] {{ end }}[INST] {{ if .System }}{{ .System }} {{ end }}{{ .Prompt }} [/INST]"
 )
+
+func makeOllamaRequestBody(req openai.ChatCompletionRequest) (io.Reader, error) {
+	if !strings.HasPrefix(req.Model, "mistral") {
+		return nil, errors.New("currently only Mistral models are supported, see https://ollama.com/library/mistral")
+	}
+
+	t := &templateRequest{
+		System: defaultSystem,
+		Tools:  "[]",
+	}
+	for _, msg := range req.Messages {
+		switch strings.ToLower(msg.Role) {
+		case openai.ChatMessageRoleSystem:
+			t.System = msg.Content
+		case openai.ChatMessageRoleUser:
+			t.Prompt += msg.Content + " "
+		case openai.ChatMessageRoleTool:
+			t.Prompt += msg.Content + " "
+		}
+	}
+
+	if len(req.Tools) > 0 {
+		t.System += systemToolExtra
+
+		req.Stream = false
+
+		tools, err := json.Marshal(req.Tools)
+		if err != nil {
+			return nil, err
+		}
+		t.Tools = string(tools)
+	}
+
+	ylog.Debug("ollama chat request", "model", req.Model, "system", t.System, "prompt", t.Prompt, "tools", t.Tools)
+
+	tmpl, err := template.New("ollama").Parse(mistralTmpl)
+	if err != nil {
+		return nil, err
+	}
+
+	prompt := bytes.NewBufferString("")
+	err = tmpl.Execute(prompt, t)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := json.Marshal(&ollamaRequest{
+		Model:  req.Model,
+		Prompt: prompt.String(),
+		Raw:    true,
+		Stream: req.Stream,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return bytes.NewBuffer(body), nil
+}
+
+func parseToolCallsFromResponse(response string) []openai.ToolCall {
+	toolCalls := make([]openai.ToolCall, 0)
+
+	response = strings.TrimPrefix(response, "[TOOL_CALLS]")
+	for _, v := range strings.Split(response, "\n") {
+		var functions []mistralFunction
+		if json.Unmarshal([]byte(v), &functions) == nil {
+			for _, f := range functions {
+				arguments, _ := json.Marshal(f.Arguments)
+				toolCalls = append(toolCalls, openai.ToolCall{
+					ID:   id.New(),
+					Type: openai.ToolTypeFunction,
+					Function: openai.FunctionCall{
+						Name:      f.Name,
+						Arguments: string(arguments),
+					},
+				})
+			}
+		}
+	}
+
+	return toolCalls
+}
 
 // GetChatCompletions implements ai.LLMProvider.
 func (p *Provider) GetChatCompletions(ctx context.Context, req openai.ChatCompletionRequest, _ metadata.M) (openai.ChatCompletionResponse, error) {
@@ -66,65 +149,13 @@ func (p *Provider) GetChatCompletions(ctx context.Context, req openai.ChatComple
 			{
 				Index: 0,
 				Message: openai.ChatCompletionMessage{
-					Role:    "assitant",
+					Role:    openai.ChatMessageRoleAssistant,
 					Content: "error occured during inference period",
 				},
-				FinishReason: "stop",
+				FinishReason: openai.FinishReasonStop,
 			},
 		},
 		Usage: openai.Usage{}, // todo
-	}
-
-	if !strings.HasPrefix(req.Model, "mistral") {
-		return res, errors.New("currently only Mistral models are supported, see https://ollama.com/library/mistral")
-	}
-
-	t := &templateRequest{
-		System: defaultSystem,
-		Tools:  "[]",
-	}
-	for _, msg := range req.Messages {
-		switch strings.ToLower(msg.Role) {
-		case "system":
-			t.System = msg.Content
-		case "user":
-			t.Prompt += msg.Content
-		case "tool":
-			t.Prompt += msg.Content
-		}
-	}
-
-	if req.Tools != nil {
-		t.System += systemToolExtra
-
-		tools, err := json.Marshal(req.Tools)
-		if err != nil {
-			return res, err
-		}
-		t.Tools = string(tools)
-	}
-
-	ylog.Debug("ollama chat request", "model", req.Model, "system", t.System, "prompt", t.Prompt, "tools", t.Tools)
-
-	tmpl, err := template.New("ollama").Parse(mistralTmpl)
-	if err != nil {
-		return res, err
-	}
-
-	prompt := bytes.NewBufferString("")
-	err = tmpl.Execute(prompt, t)
-	if err != nil {
-		return res, err
-	}
-
-	body, err := json.Marshal(&ollamaRequest{
-		Model:  req.Model,
-		Prompt: prompt.String(),
-		Raw:    true,
-		Stream: req.Stream,
-	})
-	if err != nil {
-		return res, err
 	}
 
 	urlPath, err := url.JoinPath(p.Endpoint, "api/generate")
@@ -132,51 +163,50 @@ func (p *Provider) GetChatCompletions(ctx context.Context, req openai.ChatComple
 		return res, err
 	}
 
-	resp, err := http.Post(urlPath, "application/json", bytes.NewBuffer(body))
+	body, err := makeOllamaRequestBody(req)
+	if err != nil {
+		return res, err
+	}
+
+	client := http.Client{}
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, urlPath, body)
+	if err != nil {
+		return res, err
+	}
+
+	request.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(request)
 	if err != nil {
 		return res, err
 	}
 	defer resp.Body.Close()
 
-	body, err = io.ReadAll(resp.Body)
-	if err != nil {
-		return res, err
-	}
-
 	if resp.StatusCode != http.StatusOK {
 		return res, fmt.Errorf("ollama inference error: %s", resp.Status)
 	}
 
-	ylog.Debug("ollama chat response", "body", string(body))
-
-	var o ollamaResponse
-	err = json.Unmarshal(body, &o)
+	buf, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return res, err
 	}
 
-	if o.Response != "" {
-		o.Response = strings.TrimPrefix(o.Response, "[TOOL_CALLS]")
+	var o ollamaResponse
+	err = json.Unmarshal(buf, &o)
+	if err != nil {
+		return res, err
+	}
 
+	ylog.Debug("ollama chat response", "response", o.Response)
+
+	if o.Response != "" {
 		res.Choices[0].Message.Content = o.Response
 
-		var functions []mistralFunction
-		err = json.Unmarshal([]byte(o.Response), &functions)
-		if err == nil {
-			res.Choices[0].FinishReason = "tool_calls"
-			res.Choices[0].Message.ToolCalls = make([]openai.ToolCall, 0)
-			for _, f := range functions {
-				arguments, _ := json.Marshal(f.Arguments)
-				res.Choices[0].Message.ToolCalls = append(
-					res.Choices[0].Message.ToolCalls, openai.ToolCall{
-						ID:   id.New(),
-						Type: openai.ToolTypeFunction,
-						Function: openai.FunctionCall{
-							Name:      f.Name,
-							Arguments: string(arguments),
-						},
-					},
-				)
+		if len(req.Tools) > 0 {
+			toolCalls := parseToolCallsFromResponse(o.Response)
+			if len(toolCalls) > 0 {
+				res.Choices[0].FinishReason = openai.FinishReasonToolCalls
+				res.Choices[0].Message.ToolCalls = toolCalls
 			}
 		}
 	}
@@ -184,9 +214,117 @@ func (p *Provider) GetChatCompletions(ctx context.Context, req openai.ChatComple
 	return res, nil
 }
 
+type streamResponse struct {
+	reader    io.ReadCloser
+	withTools bool
+	index     int
+	res       openai.ChatCompletionStreamResponse
+}
+
+func (s *streamResponse) Recv() (openai.ChatCompletionStreamResponse, error) {
+	var buf []byte
+	var err error
+
+	if s.withTools {
+		buf, err = io.ReadAll(s.reader)
+		if err != nil {
+			return s.res, err
+		}
+	} else {
+		buf = make([]byte, 1024)
+		n, err := s.reader.Read(buf)
+		if err != nil {
+			return s.res, err
+		}
+		buf = buf[:n]
+	}
+
+	ylog.Debug("ollama chat stream", "delta", string(buf))
+	if len(buf) == 0 {
+		s.reader.Close()
+		return s.res, io.EOF
+	}
+
+	var o ollamaResponse
+	err = json.Unmarshal(buf, &o)
+	if err != nil {
+		return s.res, err
+	}
+
+	ylog.Debug("ollama chat stream response", "response", o.Response, "done", o.Done)
+
+	s.res.Choices[0].Index++
+	s.res.Choices[0].Delta.Content = o.Response
+	if o.Done {
+		s.res.Choices[0].FinishReason = openai.FinishReasonStop
+		s.res.Usage = &openai.Usage{} // todo
+
+		if s.withTools {
+			toolCalls := parseToolCallsFromResponse(o.Response)
+			if len(toolCalls) > 0 {
+				for i := 0; i < len(toolCalls); i++ {
+					index := i
+					toolCalls[index].Index = &index
+				}
+				s.res.Choices[0].FinishReason = openai.FinishReasonToolCalls
+				s.res.Choices[0].Delta.ToolCalls = toolCalls
+			}
+		}
+	}
+
+	return s.res, nil
+}
+
 // GetChatCompletionsStream implements ai.LLMProvider.
 func (p *Provider) GetChatCompletionsStream(ctx context.Context, req openai.ChatCompletionRequest, _ metadata.M) (ai.ResponseRecver, error) {
-	panic("unimplemented")
+	urlPath, err := url.JoinPath(p.Endpoint, "api/generate")
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := makeOllamaRequestBody(req)
+	if err != nil {
+		return nil, err
+	}
+
+	client := http.Client{}
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, urlPath, body)
+	if err != nil {
+		return nil, err
+	}
+
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Accept", "text/event-stream")
+	request.Header.Set("Cache-Control", "no-cache")
+	request.Header.Set("Connection", "keep-alive")
+
+	resp, err := client.Do(request)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("ollama inference error: %s", resp.Status)
+	}
+
+	return &streamResponse{
+		reader:    resp.Body,
+		withTools: len(req.Tools) > 0,
+		index:     0,
+		res: openai.ChatCompletionStreamResponse{
+			ID:      "chatcmpl-" + id.New(29),
+			Model:   req.Model,
+			Created: time.Now().Unix(),
+			Choices: []openai.ChatCompletionStreamChoice{
+				{
+					Index: -1,
+					Delta: openai.ChatCompletionStreamChoiceDelta{
+						Role: openai.ChatMessageRoleAssistant,
+					},
+				},
+			},
+		},
+	}, nil
 }
 
 // Name implements ai.LLMProvider.


### PR DESCRIPTION
# Description

By using the [Ollama](https://ollama.com) backend provider and MistralAI models, users could build up the function calling system with all open-source deps from zero.
