### PR TITLE
chore: developers can docker run ai bridge

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,67 @@
+name: Docker
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: "Log level"
+        required: true
+        default: "warning"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@v3.5.0
+
+
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,7 +13,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: ${{ github.repository }}-zipper
 
 
 jobs:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,7 +13,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}-zipper
+  IMAGE_NAME: ${{ github.repository_owner }}/ai-bridge
 
 
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,7 @@ WORKDIR /usr/local/bin
 
 COPY --from=builder /bin/yomo .
 
-CMD ["./yomo"]
+# Smoke test
+RUN ["yomo", "version"]
+
+ENTRYPOINT ["/usr/local/bin/yomo"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM golang:1.21-alpine AS builder
+
+RUN apk update && apk add --no-cache make && apk --no-cache add git
+
+WORKDIR /
+
+COPY . .
+
+RUN GO_MODULE=$(go list -m) \
+    && TAG=$(git describe --tags 2>/dev/null || git rev-parse --short HEAD) \
+    && go build -o /bin/yomo -trimpath -ldflags "-s -w -X ${GO_MODULE}/cli.Version=${TAG}" ./cmd/yomo/main.go
+
+FROM alpine:3.17
+
+RUN apk --no-cache add ca-certificates
+
+WORKDIR /usr/local/bin
+
+COPY --from=builder /bin/yomo .
+
+CMD ["./yomo"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,11 +14,13 @@ FROM alpine:3.17
 
 RUN apk --no-cache add ca-certificates
 
-WORKDIR /workspace
+WORKDIR /zipper
 
 COPY --from=builder /bin/yomo /usr/local/bin
 
-# Smoke test
-RUN ["yomo", "version"]
+RUN echo -e "name: zipper\nhost: 0.0.0.0\nport: 9000\nbridge:\n  ai:\n    server:\n      addr: 0.0.0.0:8000\n      provider: openai\n\n    providers:\n      openai:" > /zipper/config.yaml
 
-ENTRYPOINT ["/usr/local/bin/yomo"]
+EXPOSE 9000/udp
+EXPOSE 8000/tcp
+
+CMD ["/usr/local/bin/yomo", "serve", "-c", "config.yaml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ FROM alpine:3.17
 
 RUN apk --no-cache add ca-certificates
 
-WORKDIR /usr/local/bin
+WORKDIR /workspace
 
-COPY --from=builder /bin/yomo .
+COPY --from=builder /bin/yomo /usr/local/bin
 
 # Smoke test
 RUN ["yomo", "version"]

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ GO ?= go
 GOFMT ?= gofmt "-s"
 GOFILES := $(shell find . -name "*.go")
 VETPACKAGES ?= $(shell $(GO) list ./... | grep -v /example/)
+TAGS ?= $(shell git describe --tags 2>/dev/null || git rev-parse --short HEAD)
 
 .PHONY: fmt
 fmt:

--- a/pkg/bridge/ai/ai.go
+++ b/pkg/bridge/ai/ai.go
@@ -14,8 +14,6 @@ import (
 )
 
 var (
-	// ErrNotExistsProvider is the error when the provider does not exist
-	ErrNotExistsProvider = errors.New("llm provider does not exist")
 	// ErrConfigNotFound is the error when the ai config was not found
 	ErrConfigNotFound = errors.New("ai config was not found")
 	// ErrConfigFormatError is the error when the ai config format is incorrect

--- a/pkg/bridge/ai/provider/openai/provider.go
+++ b/pkg/bridge/ai/provider/openai/provider.go
@@ -53,14 +53,18 @@ func (p *Provider) Name() string {
 
 // GetChatCompletions implements ai.LLMProvider.
 func (p *Provider) GetChatCompletions(ctx context.Context, req openai.ChatCompletionRequest, _ metadata.M) (openai.ChatCompletionResponse, error) {
-	req.Model = p.Model
+	if p.Model != "" {
+		req.Model = p.Model
+	}
 
 	return p.client.CreateChatCompletion(ctx, req)
 }
 
 // GetChatCompletionsStream implements ai.LLMProvider.
 func (p *Provider) GetChatCompletionsStream(ctx context.Context, req openai.ChatCompletionRequest, _ metadata.M) (provider.ResponseRecver, error) {
-	req.Model = p.Model
+	if p.Model != "" {
+		req.Model = p.Model
+	}
 
 	return p.client.CreateChatCompletionStream(ctx, req)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,12 +9,6 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// Function represents a yomo stream function.
-type Function struct {
-	// Name is the name of StreamFunction.
-	Name string `yaml:"name"`
-}
-
 // Config represents a yomo config.
 type Config struct {
 	// Name represents the name of the zipper.


### PR DESCRIPTION
# Description
 
 Add a Docker image publishing Action and the Dockerfile, This allows users to use the yomo command in a Docker environment.
 
After the release, users can set up a zipper in a single Docker command.
 
 ```bash
docker run -p 9000:9000/udp -p 8000:8000 -e OPENAI_API_KEY=sk-xxxxxx --rm ghcr.io/yomorun/ai-bridge:latest
```

If User wants to use their own `config.yaml`, run blow command.

```bash
docker run -p 9000:9000/udp -p 8000:8000 -v ~/path/to/config.yaml:/zipper/config.yaml ghcr.io/yomorun/ai-bridge:latest
```
