### PR TITLE
fix: error raised when function scheme `required` is null

### DIFF
--- a/ai/model.go
+++ b/ai/model.go
@@ -49,7 +49,7 @@ type FunctionDefinition = openai.FunctionDefinition
 type FunctionParameters struct {
 	Type       string                        `json:"type"`
 	Properties map[string]*ParameterProperty `json:"properties"`
-	Required   []string                      `json:"required"`
+	Required   []string                      `json:"required,omitempty"`
 }
 
 // ParameterProperty defines the property of the parameter


### PR DESCRIPTION
# Description

```bash
Invalid schema for function 'ai-sfn': None is not of type 'array'.
````
