### PR TITLE
feat: return openai error message if request llm provider failed

### DIFF
--- a/pkg/bridge/ai/api_server.go
+++ b/pkg/bridge/ai/api_server.go
@@ -226,7 +226,7 @@ func DecodeRequest[T any](r *http.Request, w http.ResponseWriter, logger *slog.L
 
 // RespondWithError writes an error to response according to the OpenAI API spec.
 func RespondWithError(w http.ResponseWriter, code int, err error, logger *slog.Logger) {
-	logger.Error("bridge server error", "error", err)
+	logger.Error("bridge server error", "err", err)
 
 	errString := err.Error()
 	oerr, ok := err.(*openai.APIError)

--- a/pkg/bridge/ai/api_server.go
+++ b/pkg/bridge/ai/api_server.go
@@ -231,10 +231,8 @@ func RespondWithError(w http.ResponseWriter, code int, err error, logger *slog.L
 	errString := err.Error()
 	oerr, ok := err.(*openai.APIError)
 	if ok {
-		if oerr.HTTPStatusCode >= 400 {
-			code = http.StatusInternalServerError
-			errString = "Internal Server Error, Please Try Again Later."
-		}
+		code = oerr.HTTPStatusCode
+		errString = oerr.Message
 	}
 
 	w.WriteHeader(code)


### PR DESCRIPTION
Return the error message from openai'client if call provider failed.

