### PR TITLE
refactor(llm-bridge): improve log and trace

### DIFF
--- a/core/server.go
+++ b/core/server.go
@@ -68,7 +68,7 @@ func NewServer(name string, opts ...ServerOption) *Server {
 		o(options)
 	}
 
-	logger := options.logger.With("component", "zipper", "zipper_name", name)
+	logger := options.logger.With("service", "zipper", "zipper_name", name)
 
 	ctx, ctxCancel := context.WithCancel(context.Background())
 

--- a/pkg/bridge/ai/ai.go
+++ b/pkg/bridge/ai/ai.go
@@ -50,7 +50,7 @@ func registerFunction(r register.Register) core.ConnMiddleware {
 				fd := ai.FunctionDefinition{}
 				err := json.Unmarshal([]byte(definition), &fd)
 				if err != nil {
-					conn.Logger.Error("unmarshal function definition", "error", err)
+					conn.Logger.Error("unmarshal function definition", "err", err)
 					return
 				}
 				err = r.RegisterFunction(tag, &fd, conn.ID(), connMd)

--- a/pkg/bridge/ai/api_server.go
+++ b/pkg/bridge/ai/api_server.go
@@ -83,7 +83,7 @@ func DecorateHandler(h http.Handler, decorates ...func(handler http.Handler) htt
 func NewBasicAPIServer(config *Config, zipperAddr, credential string, provider provider.LLMProvider, logger *slog.Logger) (*BasicAPIServer, error) {
 	zipperAddr = parseZipperAddr(zipperAddr)
 
-	logger = logger.With("namespace", "bridge")
+	logger = logger.With("namespace", "llm-bridge")
 
 	service := NewService(zipperAddr, provider, &ServiceOptions{
 		Logger:         logger,

--- a/pkg/bridge/ai/api_server.go
+++ b/pkg/bridge/ai/api_server.go
@@ -181,7 +181,6 @@ func (h *Handler) HandleOverview(w http.ResponseWriter, r *http.Request) {
 		functions[tag] = tc.Function
 	}
 
-	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(&ai.OverviewResponse{Functions: functions})
 }
 
@@ -233,6 +232,7 @@ func (h *Handler) HandleChatCompletions(w http.ResponseWriter, r *http.Request) 
 
 	req, err := DecodeRequest[openai.ChatCompletionRequest](r, w, h.service.logger)
 	if err != nil {
+		ww.Err = err
 		return
 	}
 

--- a/pkg/bridge/ai/api_server.go
+++ b/pkg/bridge/ai/api_server.go
@@ -154,7 +154,7 @@ func decorateReqContext(service *Service, logger *slog.Logger) func(handler http
 				"duration", duration,
 			}
 			if ww.Err != nil {
-				logger.Error("llm birdge request", append(logContent, "error", ww.Err)...)
+				logger.Error("llm birdge request", append(logContent, "err", ww.Err)...)
 			} else {
 				logger.Info("llm birdge request", logContent...)
 			}

--- a/pkg/bridge/ai/provider/xai/provider_test.go
+++ b/pkg/bridge/ai/provider/xai/provider_test.go
@@ -3,6 +3,7 @@ package xai
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/sashabaranov/go-openai"
 	"github.com/stretchr/testify/assert"
@@ -32,11 +33,14 @@ func TestXAIProvider_GetChatCompletions(t *testing.T) {
 		Model:    "groq-beta",
 	}
 
-	_, err := provider.GetChatCompletions(context.TODO(), req, nil)
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Second)
+	defer cancel()
+
+	_, err := provider.GetChatCompletions(ctx, req, nil)
 	assert.Error(t, err)
 	t.Log(err)
 
-	_, err = provider.GetChatCompletionsStream(context.TODO(), req, nil)
+	_, err = provider.GetChatCompletionsStream(ctx, req, nil)
 	assert.Error(t, err)
 	t.Log(err)
 
@@ -44,11 +48,11 @@ func TestXAIProvider_GetChatCompletions(t *testing.T) {
 		Messages: msgs,
 	}
 
-	_, err = provider.GetChatCompletions(context.TODO(), req, nil)
+	_, err = provider.GetChatCompletions(ctx, req, nil)
 	assert.Error(t, err)
 	t.Log(err)
 
-	_, err = provider.GetChatCompletionsStream(context.TODO(), req, nil)
+	_, err = provider.GetChatCompletionsStream(ctx, req, nil)
 	assert.Error(t, err)
 	t.Log(err)
 }

--- a/pkg/bridge/ai/response_writer.go
+++ b/pkg/bridge/ai/response_writer.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"sync"
 	"time"
 )
 
@@ -13,6 +14,7 @@ type ResponseWriter struct {
 	IsStream   bool
 	Err        error
 	TTFT       time.Time
+	once       sync.Once
 	underlying http.ResponseWriter
 }
 
@@ -35,7 +37,9 @@ func (w *ResponseWriter) Write(b []byte) (int, error) {
 
 // WriteHeader writes the header to the underlying ResponseWriter.
 func (w *ResponseWriter) WriteHeader(code int) {
-	w.underlying.WriteHeader(code)
+	w.once.Do(func() {
+		w.underlying.WriteHeader(code)
+	})
 }
 
 // WriteStreamEvent writes the event to the underlying ResponseWriter.

--- a/pkg/bridge/ai/response_writer.go
+++ b/pkg/bridge/ai/response_writer.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
-	"sync"
 	"time"
 )
 
@@ -14,7 +13,6 @@ type ResponseWriter struct {
 	IsStream   bool
 	Err        error
 	TTFT       time.Time
-	once       sync.Once
 	underlying http.ResponseWriter
 }
 
@@ -37,9 +35,7 @@ func (w *ResponseWriter) Write(b []byte) (int, error) {
 
 // WriteHeader writes the header to the underlying ResponseWriter.
 func (w *ResponseWriter) WriteHeader(code int) {
-	w.once.Do(func() {
-		w.underlying.WriteHeader(code)
-	})
+	w.underlying.WriteHeader(code)
 }
 
 // WriteStreamEvent writes the event to the underlying ResponseWriter.

--- a/pkg/bridge/ai/response_writer.go
+++ b/pkg/bridge/ai/response_writer.go
@@ -1,0 +1,86 @@
+package ai
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+)
+
+// ResponseWriter is a wrapper for http.ResponseWriter.
+// It is used to add TTFT and Err to the response.
+type ResponseWriter struct {
+	IsStream   bool
+	Err        error
+	TTFT       time.Time
+	underlying http.ResponseWriter
+}
+
+// NewResponseWriter returns a new ResponseWriter.
+func NewResponseWriter(w http.ResponseWriter) *ResponseWriter {
+	return &ResponseWriter{
+		underlying: w,
+	}
+}
+
+// Header returns the headers of the underlying ResponseWriter.
+func (w *ResponseWriter) Header() http.Header {
+	return w.underlying.Header()
+}
+
+// Write writes the data to the underlying ResponseWriter.
+func (w *ResponseWriter) Write(b []byte) (int, error) {
+	return w.underlying.Write(b)
+}
+
+// WriteHeader writes the header to the underlying ResponseWriter.
+func (w *ResponseWriter) WriteHeader(code int) {
+	w.underlying.WriteHeader(code)
+}
+
+// WriteStreamEvent writes the event to the underlying ResponseWriter.
+func (w *ResponseWriter) WriteStreamEvent(event any) error {
+	if _, err := io.WriteString(w, "data: "); err != nil {
+		return err
+	}
+	if err := json.NewEncoder(w).Encode(event); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, "\n"); err != nil {
+		return err
+	}
+	flusher, ok := w.underlying.(http.Flusher)
+	if ok {
+		flusher.Flush()
+	}
+	return nil
+}
+
+// WriteStreamDone writes the done event to the underlying ResponseWriter.
+func (w *ResponseWriter) WriteStreamDone() error {
+	_, err := io.WriteString(w, "data: [DONE]")
+
+	flusher, ok := w.underlying.(http.Flusher)
+	if ok {
+		flusher.Flush()
+	}
+
+	return err
+}
+
+// SetStreamHeader sets the stream headers of the underlying ResponseWriter.
+func (w *ResponseWriter) SetStreamHeader() http.Header {
+	h := w.Header()
+	h.Set("Content-Type", "text/event-stream")
+	h.Set("Cache-Control", "no-cache, must-revalidate")
+	h.Set("x-content-type-options", "nosniff")
+	return h
+}
+
+// Flush flushes the underlying ResponseWriter.
+func (w *ResponseWriter) Flush() {
+	flusher, ok := w.underlying.(http.Flusher)
+	if ok {
+		flusher.Flush()
+	}
+}

--- a/pkg/bridge/ai/response_writer_test.go
+++ b/pkg/bridge/ai/response_writer_test.go
@@ -1,0 +1,34 @@
+package ai
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sashabaranov/go-openai"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResponseWriter(t *testing.T) {
+	recorder := httptest.NewRecorder()
+
+	w := NewResponseWriter(recorder)
+
+	h := w.SetStreamHeader()
+
+	err := w.WriteStreamEvent(openai.ChatCompletionResponse{
+		ID: "chatcmpl-123",
+	})
+	assert.NoError(t, err)
+
+	err = w.WriteStreamDone()
+	assert.NoError(t, err)
+
+	got := recorder.Body.String()
+
+	want := `data: {"id":"chatcmpl-123","object":"","created":0,"model":"","choices":null,"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0,"prompt_tokens_details":null,"completion_tokens_details":null},"system_fingerprint":""}
+
+data: [DONE]`
+
+	assert.Equal(t, want, got)
+	assert.Equal(t, recorder.Header(), h)
+}

--- a/pkg/bridge/ai/service.go
+++ b/pkg/bridge/ai/service.go
@@ -38,8 +38,6 @@ type Service struct {
 type ServiceOptions struct {
 	// Logger is the logger for the service
 	Logger *slog.Logger
-	// Tracer is the tracer for the service
-	Tracer trace.Tracer
 	// CredentialFunc is the function for getting the credential from the request
 	CredentialFunc func(r *http.Request) (string, error)
 	// CallerCacheSize is the size of the caller's cache
@@ -64,9 +62,6 @@ func NewService(zipperAddr string, provider provider.LLMProvider, opt *ServiceOp
 func initOption(opt *ServiceOptions) *ServiceOptions {
 	if opt == nil {
 		opt = &ServiceOptions{}
-	}
-	if opt.Tracer == nil {
-		opt.Tracer = noop.NewTracerProvider().Tracer("yomo-ai-bridge")
 	}
 	if opt.Logger == nil {
 		opt.Logger = ylog.Default()
@@ -136,7 +131,10 @@ func (srv *Service) LoadOrCreateCaller(r *http.Request) (*Caller, error) {
 }
 
 // GetInvoke returns the invoke response
-func (srv *Service) GetInvoke(ctx context.Context, userInstruction, baseSystemMessage, transID string, caller *Caller, includeCallStack bool) (*ai.InvokeResponse, error) {
+func (srv *Service) GetInvoke(ctx context.Context, userInstruction, baseSystemMessage, transID string, caller *Caller, includeCallStack bool, tracer trace.Tracer) (*ai.InvokeResponse, error) {
+	if tracer == nil {
+		tracer = new(noop.Tracer)
+	}
 	md := caller.Metadata().Clone()
 	// read tools attached to the metadata
 	tcs, err := register.ListToolCalls(md)
@@ -159,12 +157,14 @@ func (srv *Service) GetInvoke(ctx context.Context, userInstruction, baseSystemMe
 		promptUsage     int
 		completionUsage int
 	)
-	_, span := srv.option.Tracer.Start(ctx, "first_call")
+	var (
+		_, span    = tracer.Start(ctx, "first_call")
+		_, reqSpan = tracer.Start(ctx, "completions_request")
+	)
 	chatCompletionResponse, err := srv.provider.GetChatCompletions(ctx, req, md)
 	if err != nil {
 		return nil, err
 	}
-	span.End()
 	promptUsage = chatCompletionResponse.Usage.PromptTokens
 	completionUsage = chatCompletionResponse.Usage.CompletionTokens
 
@@ -175,8 +175,10 @@ func (srv *Service) GetInvoke(ctx context.Context, userInstruction, baseSystemMe
 	}
 	// if no tool_calls fired, just return the llm text result
 	if res.FinishReason != string(openai.FinishReasonToolCalls) {
+		reqSpan.End()
 		return res, nil
 	}
+	span.End()
 
 	// run llm function calls
 	srv.logger.Debug(">>>> start 1st call response",
@@ -185,7 +187,7 @@ func (srv *Service) GetInvoke(ctx context.Context, userInstruction, baseSystemMe
 
 	srv.logger.Debug(">> run function calls", "transID", transID, "res.ToolCalls", fmt.Sprintf("%+v", res.ToolCalls))
 
-	_, span = srv.option.Tracer.Start(ctx, "run_sfn")
+	_, span = tracer.Start(ctx, "run_sfn")
 	reqID := id.New(16)
 	llmCalls, err := caller.Call(ctx, transID, reqID, res.ToolCalls)
 	if err != nil {
@@ -202,7 +204,7 @@ func (srv *Service) GetInvoke(ctx context.Context, userInstruction, baseSystemMe
 	req2 := openai.ChatCompletionRequest{
 		Messages: messages2,
 	}
-	_, span = srv.option.Tracer.Start(ctx, "second_call")
+	_, span = tracer.Start(ctx, "second_call")
 	chatCompletionResponse2, err := srv.provider.GetChatCompletions(ctx, req2, md)
 	if err != nil {
 		return nil, err
@@ -228,8 +230,11 @@ func (srv *Service) GetInvoke(ctx context.Context, userInstruction, baseSystemMe
 }
 
 // GetChatCompletions accepts openai.ChatCompletionRequest and responds to http.ResponseWriter.
-func (srv *Service) GetChatCompletions(ctx context.Context, req openai.ChatCompletionRequest, transID string, caller *Caller, w http.ResponseWriter) error {
-	reqCtx, reqSpan := srv.option.Tracer.Start(ctx, "completions_request")
+func (srv *Service) GetChatCompletions(ctx context.Context, req openai.ChatCompletionRequest, transID string, caller *Caller, w *ResponseWriter, tracer trace.Tracer) error {
+	if tracer == nil {
+		tracer = new(noop.Tracer)
+	}
+	reqCtx, reqSpan := tracer.Start(ctx, "completions_request")
 	md := caller.Metadata().Clone()
 
 	// 1. find all hosting tool sfn
@@ -260,25 +265,26 @@ func (srv *Service) GetChatCompletions(ctx context.Context, req openai.ChatCompl
 
 	// 4. request first chat for getting tools
 	if req.Stream {
-		_, firstCallSpan := srv.option.Tracer.Start(reqCtx, "first_call_request")
+		w.IsStream = true
+		_, firstCallSpan := tracer.Start(reqCtx, "first_call_request")
 
 		resStream, err := srv.provider.GetChatCompletionsStream(reqCtx, req, md)
 		if err != nil {
 			return err
 		}
+
+		w.SetStreamHeader()
+
 		var (
-			flusher        = eventFlusher(w)
 			isFunctionCall = false
-		)
-		var (
-			i             int // number of chunks
-			j             int // number of tool call chunks
-			firstRespSpan trace.Span
-			respSpan      trace.Span
+			i              int // number of chunks
+			j              int // number of tool call chunks
+			firstRespSpan  trace.Span
+			respSpan       trace.Span
 		)
 		for {
 			if i == 0 {
-				_, firstRespSpan = srv.option.Tracer.Start(reqCtx, "first_call_response_in_stream")
+				_, firstRespSpan = tracer.Start(reqCtx, "first_call_response_in_stream")
 			}
 			streamRes, err := resStream.Recv()
 			if err == io.EOF {
@@ -323,18 +329,18 @@ func (srv *Service) GetChatCompletions(ctx context.Context, req openai.ChatCompl
 				}
 				j++
 			} else if !isFunctionCall {
-				_ = writeStreamEvent(w, flusher, streamRes)
+				_ = w.WriteStreamEvent(streamRes)
 			}
 			if i == 0 && j == 0 && !isFunctionCall {
 				reqSpan.End()
-				recordTTFT(ctx, srv.option.Tracer)
-				_, respSpan = srv.option.Tracer.Start(ctx, "response_in_stream(TBT)")
+				recordTTFT(ctx, tracer, w)
+				_, respSpan = tracer.Start(ctx, "response_in_stream(TBT)")
 			}
 			i++
 		}
 		if !isFunctionCall {
 			respSpan.End()
-			return writeStreamDone(w, flusher)
+			return w.WriteStreamDone()
 		}
 		firstRespSpan.End()
 		toolCalls = mapToSliceTools(toolCallsMap)
@@ -344,9 +350,9 @@ func (srv *Service) GetChatCompletions(ctx context.Context, req openai.ChatCompl
 			Role:      openai.ChatMessageRoleAssistant,
 		}
 		reqSpan.End()
-		flusher.Flush()
+		w.Flush() // flush the header before write body to the client.
 	} else {
-		_, firstCallSpan := srv.option.Tracer.Start(reqCtx, "first_call")
+		_, firstCallSpan := tracer.Start(reqCtx, "first_call")
 		resp, err := srv.provider.GetChatCompletions(ctx, req, md)
 		if err != nil {
 			return err
@@ -366,7 +372,7 @@ func (srv *Service) GetChatCompletions(ctx context.Context, req openai.ChatCompl
 		} else if rawReq.Stream {
 			// if raw request is stream mode, we should return the stream response
 			// WARN: this is a temporary solution for ollama provider
-			flusher := eventFlusher(w)
+			w.SetStreamHeader()
 			// choices
 			choices := make([]openai.ChatCompletionStreamChoice, 0)
 			for _, choice := range resp.Choices {
@@ -394,7 +400,7 @@ func (srv *Service) GetChatCompletions(ctx context.Context, req openai.ChatCompl
 				// PromptAnnotations:
 				// PromptFilterResults:
 			}
-			writeStreamEvent(w, flusher, streamRes)
+			_ = w.WriteStreamEvent(streamRes)
 			// usage
 			if req.StreamOptions != nil && req.StreamOptions.IncludeUsage {
 				streamRes = openai.ChatCompletionStreamResponse{
@@ -409,10 +415,10 @@ func (srv *Service) GetChatCompletions(ctx context.Context, req openai.ChatCompl
 						TotalTokens:      totalUsage,
 					},
 				}
-				writeStreamEvent(w, flusher, streamRes)
+				_ = w.WriteStreamEvent(streamRes)
 			}
 			// done
-			return writeStreamDone(w, flusher)
+			return w.WriteStreamDone()
 		} else {
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(resp)
@@ -420,10 +426,10 @@ func (srv *Service) GetChatCompletions(ctx context.Context, req openai.ChatCompl
 		}
 	}
 
-	resCtx, resSpan := srv.option.Tracer.Start(ctx, "completions_response")
+	resCtx, resSpan := tracer.Start(ctx, "completions_response")
 	defer resSpan.End()
 
-	_, sfnSpan := srv.option.Tracer.Start(resCtx, "run_sfn")
+	_, sfnSpan := tracer.Start(resCtx, "run_sfn")
 
 	// 5. find sfns that hit the function call
 	fnCalls := findTagTools(tagTools, toolCalls)
@@ -449,8 +455,7 @@ func (srv *Service) GetChatCompletions(ctx context.Context, req openai.ChatCompl
 	srv.logger.Debug(" #2 second call", "request", fmt.Sprintf("%+v", req))
 
 	if req.Stream {
-		_, secondCallSpan := srv.option.Tracer.Start(resCtx, "second_call_request")
-		flusher := w.(http.Flusher)
+		_, secondCallSpan := tracer.Start(resCtx, "second_call_request")
 		resStream, err := srv.provider.GetChatCompletionsStream(resCtx, req, md)
 		if err != nil {
 			return err
@@ -463,14 +468,14 @@ func (srv *Service) GetChatCompletions(ctx context.Context, req openai.ChatCompl
 		)
 		for {
 			if i == 0 {
-				recordTTFT(resCtx, srv.option.Tracer)
-				_, secondRespSpan = srv.option.Tracer.Start(resCtx, "second_call_response_in_stream(TBT)")
+				recordTTFT(resCtx, tracer, w)
+				_, secondRespSpan = tracer.Start(resCtx, "second_call_response_in_stream(TBT)")
 			}
 			i++
 			streamRes, err := resStream.Recv()
 			if err == io.EOF {
 				secondRespSpan.End()
-				return writeStreamDone(w, flusher)
+				return w.WriteStreamDone()
 			}
 			if err != nil {
 				return err
@@ -480,10 +485,10 @@ func (srv *Service) GetChatCompletions(ctx context.Context, req openai.ChatCompl
 				streamRes.Usage.CompletionTokens += completionUsage
 				streamRes.Usage.TotalTokens += totalUsage
 			}
-			_ = writeStreamEvent(w, flusher, streamRes)
+			_ = w.WriteStreamEvent(streamRes)
 		}
 	} else {
-		_, secondCallSpan := srv.option.Tracer.Start(resCtx, "second_call")
+		_, secondCallSpan := tracer.Start(resCtx, "second_call")
 
 		resp, err := srv.provider.GetChatCompletions(resCtx, req, md)
 		if err != nil {
@@ -594,28 +599,6 @@ func findTagTools(tagTools map[uint32]openai.Tool, toolCalls []openai.ToolCall) 
 	return fnCalls
 }
 
-func writeStreamEvent(w http.ResponseWriter, flusher http.Flusher, streamRes openai.ChatCompletionStreamResponse) error {
-	if _, err := io.WriteString(w, "data: "); err != nil {
-		return err
-	}
-	if err := json.NewEncoder(w).Encode(streamRes); err != nil {
-		return err
-	}
-	if _, err := io.WriteString(w, "\n"); err != nil {
-		return err
-	}
-	flusher.Flush()
-
-	return nil
-}
-
-func writeStreamDone(w http.ResponseWriter, flusher http.Flusher) error {
-	_, err := io.WriteString(w, "data: [DONE]")
-	flusher.Flush()
-
-	return err
-}
-
 func (srv *Service) prepareMessages(baseSystemMessage string, userInstruction string, chainMessage ai.ChainMessage, tools []openai.Tool, withTool bool) []openai.ChatCompletionMessage {
 	systemInstructions := []string{"## Instructions\n"}
 
@@ -676,15 +659,6 @@ func mapToSliceTools(m map[int]openai.ToolCall) []openai.ToolCall {
 	return arr
 }
 
-func eventFlusher(w http.ResponseWriter) http.Flusher {
-	h := w.Header()
-	h.Set("Content-Type", "text/event-stream")
-	h.Set("Cache-Control", "no-cache, must-revalidate")
-	h.Set("x-content-type-options", "nosniff")
-	flusher := w.(http.Flusher)
-	return flusher
-}
-
 func prepareToolCalls(tcs map[uint32]openai.Tool) []openai.Tool {
 	// prepare tools
 	toolCalls := make([]openai.Tool, len(tcs))
@@ -708,16 +682,17 @@ func transToolMessage(msgs []openai.ChatCompletionMessage) []ai.ToolMessage {
 	return toolMessages
 }
 
-func recordTTFT(ctx context.Context, tracer trace.Tracer) {
+func recordTTFT(ctx context.Context, tracer trace.Tracer, w *ResponseWriter) {
 	_, span := tracer.Start(ctx, "TTFT")
 	time.Sleep(time.Millisecond)
 	span.End()
+	w.TTFT = time.Now()
 	time.Sleep(time.Millisecond)
 }
 
 // patchOllamaRequest patch the request for ollama provider(ollama function calling unsupported in stream mode)
 func (srv *Service) patchOllamaRequest(req openai.ChatCompletionRequest) openai.ChatCompletionRequest {
-	ylog.Debug("before request",
+	srv.logger.Debug("before request",
 		"stream", req.Stream,
 		"provider", srv.provider.Name(),
 		fmt.Sprintf("tools[%d]", len(req.Tools)), req.Tools,
@@ -728,7 +703,7 @@ func (srv *Service) patchOllamaRequest(req openai.ChatCompletionRequest) openai.
 	if srv.provider.Name() == "ollama" && len(req.Tools) > 0 {
 		req.Stream = false
 	}
-	ylog.Debug("patch request",
+	srv.logger.Debug("patch request",
 		"stream", req.Stream,
 		"provider", srv.provider.Name(),
 		fmt.Sprintf("tools[%d]", len(req.Tools)), req.Tools,

--- a/pkg/bridge/ai/service.go
+++ b/pkg/bridge/ai/service.go
@@ -291,6 +291,11 @@ func (srv *Service) GetChatCompletions(ctx context.Context, req openai.ChatCompl
 			if err != nil {
 				return err
 			}
+
+			if len(streamRes.PromptFilterResults) > 0 {
+				continue
+			}
+
 			if streamRes.Usage != nil {
 				promptUsage = streamRes.Usage.PromptTokens
 				completionUsage = streamRes.Usage.CompletionTokens

--- a/pkg/bridge/ai/service_test.go
+++ b/pkg/bridge/ai/service_test.go
@@ -214,7 +214,7 @@ func TestServiceInvoke(t *testing.T) {
 
 			caller.SetSystemPrompt(tt.args.systemPrompt, SystemPromptOpOverwrite)
 
-			resp, err := service.GetInvoke(context.TODO(), tt.args.userInstruction, tt.args.baseSystemMessage, "transID", caller, true)
+			resp, err := service.GetInvoke(context.TODO(), tt.args.userInstruction, tt.args.baseSystemMessage, "transID", caller, true, nil)
 			assert.NoError(t, err)
 
 			assert.Equal(t, tt.wantUsage, resp.TokenUsage)
@@ -384,7 +384,7 @@ func TestServiceChatCompletion(t *testing.T) {
 			caller.SetSystemPrompt(tt.args.systemPrompt, SystemPromptOpOverwrite)
 
 			w := httptest.NewRecorder()
-			err = service.GetChatCompletions(context.TODO(), tt.args.request, "transID", caller, w)
+			err = service.GetChatCompletions(context.TODO(), tt.args.request, "transID", caller, NewResponseWriter(w), nil)
 			assert.NoError(t, err)
 
 			assert.Equal(t, tt.wantRequest, pd.RequestRecords())

--- a/sfn.go
+++ b/sfn.go
@@ -59,7 +59,7 @@ func NewStreamFunction(name, zipperAddr string, opts ...SfnOption) StreamFunctio
 	client := core.NewClient(name, zipperAddr, core.ClientTypeStreamFunction, clientOpts...)
 
 	client.Logger = client.Logger.With(
-		"component", core.ClientTypeStreamFunction.String(),
+		"namespace", core.ClientTypeStreamFunction.String(),
 		"sfn_id", client.ClientID(),
 		"sfn_name", client.Name(),
 		"zipper_addr", zipperAddr,

--- a/sfn.go
+++ b/sfn.go
@@ -59,7 +59,7 @@ func NewStreamFunction(name, zipperAddr string, opts ...SfnOption) StreamFunctio
 	client := core.NewClient(name, zipperAddr, core.ClientTypeStreamFunction, clientOpts...)
 
 	client.Logger = client.Logger.With(
-		"service", core.ClientTypeStreamFunction.String(),
+		"service", "stream-function",
 		"sfn_id", client.ClientID(),
 		"sfn_name", client.Name(),
 		"zipper_addr", zipperAddr,

--- a/sfn.go
+++ b/sfn.go
@@ -59,7 +59,7 @@ func NewStreamFunction(name, zipperAddr string, opts ...SfnOption) StreamFunctio
 	client := core.NewClient(name, zipperAddr, core.ClientTypeStreamFunction, clientOpts...)
 
 	client.Logger = client.Logger.With(
-		"namespace", core.ClientTypeStreamFunction.String(),
+		"service", core.ClientTypeStreamFunction.String(),
 		"sfn_id", client.ClientID(),
 		"sfn_name", client.Name(),
 		"zipper_addr", zipperAddr,

--- a/source.go
+++ b/source.go
@@ -41,7 +41,7 @@ func NewSource(name, zipperAddr string, opts ...SourceOption) Source {
 	client := core.NewClient(name, zipperAddr, core.ClientTypeSource, clientOpts...)
 
 	client.Logger = client.Logger.With(
-		"component", core.ClientTypeSource.String(),
+		"namespace", core.ClientTypeSource.String(),
 		"source_id", client.ClientID(),
 		"source_name", client.Name(),
 		"zipper_addr", zipperAddr,

--- a/source.go
+++ b/source.go
@@ -41,7 +41,7 @@ func NewSource(name, zipperAddr string, opts ...SourceOption) Source {
 	client := core.NewClient(name, zipperAddr, core.ClientTypeSource, clientOpts...)
 
 	client.Logger = client.Logger.With(
-		"namespace", core.ClientTypeSource.String(),
+		"service", core.ClientTypeSource.String(),
 		"source_id", client.ClientID(),
 		"source_name", client.Name(),
 		"zipper_addr", zipperAddr,

--- a/source.go
+++ b/source.go
@@ -41,7 +41,7 @@ func NewSource(name, zipperAddr string, opts ...SourceOption) Source {
 	client := core.NewClient(name, zipperAddr, core.ClientTypeSource, clientOpts...)
 
 	client.Logger = client.Logger.With(
-		"service", core.ClientTypeSource.String(),
+		"service", "source",
 		"source_id", client.ClientID(),
 		"source_name", client.Name(),
 		"zipper_addr", zipperAddr,


### PR DESCRIPTION
1. Enhance llm bridge logging, add `service`, `namespace`, `traceId`, `requestId`, `duration` field.
2. The Bridge's http handler supports the injection of tracer.
3. Yomo exports the global trace client.
4. Add new `ResponseWriter` struct, the `ResponseWriter` supports record errors and TTFT timing.