### PR TITLE
docs: rename wasm32-wai to wasm32-wasip1

### DIFF
--- a/docs/pages/docs/wasm-c.mdx
+++ b/docs/pages/docs/wasm-c.mdx
@@ -75,13 +75,12 @@ void yomo_handler() {
 ### Compile to [WASI](https://wasi.dev/)
 
 ```bash
-# download wasi-sdk from https://github.com/WebAssembly/wasi-sdk/releases,
-# and specify wasi-sdk version and path
+# download wasi-sdk from https://github.com/WebAssembly/wasi-sdk/releases
 
-$ export WASI_VERSION_FULL=20.0
-$ export WASI_SDK_PATH=~/Downloads/wasi-sdk-$WASI_VERSION_FULL
+# specify the wasi-sdk directory path according to your system
+$ export WASI_SDK_PATH=~/Downloads/wasi-sdk-25.0-arm64-macos
 
-$ $WASI_SDK_PATH/bin/clang --target=wasm32-wasi \
+$ $WASI_SDK_PATH/bin/clang --target=wasm32-wasip1 \
     --sysroot=$WASI_SDK_PATH/share/wasi-sysroot \
     -nostartfiles -fvisibility=hidden -O3 \
     -Wl,--no-entry,--export=yomo_init,--export=yomo_handler,--export=yomo_observe_datatags \

--- a/docs/pages/docs/wasm-rust.mdx
+++ b/docs/pages/docs/wasm-rust.mdx
@@ -76,8 +76,8 @@ yomo = "0.3"
 Compile to wasm:
 
 ```bash
-$ rustup target add wasm32-wasi
-$ cargo build --release --target wasm32-wasi
+$ rustup target add wasm32-wasip1
+$ cargo build --release --target wasm32-wasip1
 ```
 
 ### Run Streaming Serverless Function

--- a/example/7-wasm/sfn/c/README.md
+++ b/example/7-wasm/sfn/c/README.md
@@ -7,11 +7,10 @@ download from https://github.com/WebAssembly/wasi-sdk/releases
 ## Build
 
 ```sh
-# specify the wasi-sdk version and the directory path according to your system
-export WASI_VERSION_FULL=20.0
-export WASI_SDK_PATH=~/Downloads/wasi-sdk-$WASI_VERSION_FULL
+# specify the wasi-sdk directory path according to your system
+export WASI_SDK_PATH=~/Downloads/wasi-sdk-25.0-arm64-macos
 
-$WASI_SDK_PATH/bin/clang --target=wasm32-wasi \
+$WASI_SDK_PATH/bin/clang --target=wasm32-wasip1 \
     --sysroot=$WASI_SDK_PATH/share/wasi-sysroot \
     -nostartfiles -fvisibility=hidden -O3 \
     -Wl,--no-entry,--export=yomo_init,--export=yomo_handler,--export=yomo_observe_datatags \

--- a/example/7-wasm/sfn/rust/README.md
+++ b/example/7-wasm/sfn/rust/README.md
@@ -7,16 +7,16 @@ hence it will be convenient for developers by importing this crate to your app
 istead of implementing our wasm api spec. See [src/lib.rs](src/lib.rs) for more
 details.
 
-## Add wasm32-wasi target
+## Add wasm32-wasip1 target
 
 ```sh
-rustup target add wasm32-wasi
+rustup target add wasm32-wasip1
 ```
 
 ## Build
 
 ```sh
-cargo build --release --target wasm32-wasi
+cargo build --release --target wasm32-wasip1
 
 cp target/wasm32-wasi/release/sfn.wasm ..
 ```


### PR DESCRIPTION
# Description

The WASI specification was released as 0.2.0 ("WASIp2") in January 2024. The previous target's name wasm32-wasi was then renamed to wasm32-wasip1.

See https://github.com/rust-lang/compiler-team/issues/607
