### PR TITLE
feat: auth pkg supports register as default

### DIFF
--- a/core/server.go
+++ b/core/server.go
@@ -287,7 +287,7 @@ func (s *Server) handleConn(conn *Connection) {
 }
 
 func (s *Server) authenticate(hf *frame.HandshakeFrame) (metadata.M, error) {
-	md, err := auth.Authenticate(s.opts.auths, hf)
+	md, err := auth.Authenticate(s.opts.auths, auth.DefaultAuth(), hf)
 	if err != nil {
 		s.logger.Error(
 			"authentication failed",


### PR DESCRIPTION
Add `auth.RegisterAsDefault` to support setting default authentication in multi-auth settings.