### PR TITLE
feat: remove tag from llm-sfn

### DIFF
--- a/ai/function_call.go
+++ b/ai/function_call.go
@@ -5,8 +5,13 @@ import (
 	"errors"
 )
 
-// ReducerTag is the observed tag of the reducer
-var ReducerTag uint32 = 0xE001
+const (
+	// ReducerTag is the observed tag of the reducer
+	ReducerTag uint32 = 0xE001
+	// FunctionCallTag is the observed tag of the function call,
+	// All llm-sfn will use this tag and function name as the target to route the data.
+	FunctionCallTag uint32 = 0xE002
+)
 
 // FunctionCall describes the data structure when invoking the sfn function
 type FunctionCall struct {

--- a/ai/model.go
+++ b/ai/model.go
@@ -10,7 +10,7 @@ type ErrorResponse struct {
 
 // OverviewResponse is the response for overview
 type OverviewResponse struct {
-	Functions map[uint32]*openai.FunctionDefinition // key is the tag of yomo
+	Functions []*openai.FunctionDefinition
 }
 
 // InvokeRequest is the request from user to BasicAPIServer
@@ -24,7 +24,7 @@ type InvokeResponse struct {
 	// Content is the content from llm api response
 	Content string `json:"content,omitempty"`
 	// ToolCalls is the toolCalls from llm api response
-	ToolCalls map[uint32][]*openai.ToolCall `json:"tool_calls,omitempty"`
+	ToolCalls []openai.ToolCall `json:"tool_calls,omitempty"`
 	// ToolMessages is the tool messages from llm api response
 	ToolMessages []ToolMessage `json:"tool_messages,omitempty"`
 	// FinishReason is the finish reason from llm api response

--- a/ai/model.go
+++ b/ai/model.go
@@ -73,6 +73,3 @@ type ChainMessage struct {
 	// ToolMessages is the tool messages aggragated from reducer-sfn by AI service
 	ToolMessages []ToolMessage
 }
-
-// FunctionDefinitionKey is the yomo metadata key for function definition
-const FunctionDefinitionKey = "function-definition"

--- a/ai/openai.go
+++ b/ai/openai.go
@@ -9,7 +9,7 @@ import (
 )
 
 // ConvertToInvokeResponse converts openai.ChatCompletionResponse struct to InvokeResponse struct.
-func ConvertToInvokeResponse(res *openai.ChatCompletionResponse, tcs map[uint32]openai.Tool) (*InvokeResponse, error) {
+func ConvertToInvokeResponse(res *openai.ChatCompletionResponse, tools []openai.Tool) (*InvokeResponse, error) {
 	choice := res.Choices[0]
 	ylog.Debug(">>finish_reason", "reason", choice.FinishReason)
 	responseMessage := res.Choices[0].Message
@@ -43,17 +43,14 @@ func ConvertToInvokeResponse(res *openai.ChatCompletionResponse, tcs map[uint32]
 		return result, errors.New("finish_reason is tool_calls, but no tool calls found")
 	}
 
-	// functions may be more than one
 	for _, call := range calls {
-		for tag, tc := range tcs {
-			ylog.Debug(">> compare tool call", "tag", tag, "tc", tc.Function.Name, "call", call.Function.Name)
+		for _, tc := range tools {
+			ylog.Debug(">> compare tool call", "tc", tc.Function.Name, "call", call.Function.Name)
 			if tc.Function.Name == call.Function.Name && tc.Type == call.Type {
 				if result.ToolCalls == nil {
-					result.ToolCalls = make(map[uint32][]*openai.ToolCall)
+					result.ToolCalls = make([]openai.ToolCall, 0)
 				}
-				// create a new variable to hold the current call
-				currentCall := call
-				result.ToolCalls[tag] = append(result.ToolCalls[tag], &currentCall)
+				result.ToolCalls = append(result.ToolCalls, call)
 			}
 		}
 	}

--- a/ai/openai_test.go
+++ b/ai/openai_test.go
@@ -9,8 +9,8 @@ import (
 
 func TestConvertToInvokeResponse(t *testing.T) {
 	type args struct {
-		res *openai.ChatCompletionResponse
-		tcs map[uint32]openai.Tool
+		res   *openai.ChatCompletionResponse
+		tools []openai.Tool
 	}
 	tests := []struct {
 		name     string
@@ -44,8 +44,8 @@ func TestConvertToInvokeResponse(t *testing.T) {
 						TotalTokens:      150,
 					},
 				},
-				tcs: map[uint32]openai.Tool{
-					9: {
+				tools: []openai.Tool{
+					{
 						Type:     openai.ToolTypeFunction,
 						Function: &openai.FunctionDefinition{Name: "get-weather"},
 					},
@@ -53,10 +53,8 @@ func TestConvertToInvokeResponse(t *testing.T) {
 			},
 			expected: &InvokeResponse{
 				Content: "How is the weather today?",
-				ToolCalls: map[uint32][]*openai.ToolCall{
-					9: {
-						{Type: openai.ToolTypeFunction, Function: openai.FunctionCall{Name: "get-weather"}},
-					},
+				ToolCalls: []openai.ToolCall{
+					{Type: openai.ToolTypeFunction, Function: openai.FunctionCall{Name: "get-weather"}},
 				},
 				FinishReason: "tool_calls",
 				TokenUsage:   TokenUsage{PromptTokens: 50, CompletionTokens: 100},
@@ -73,7 +71,7 @@ func TestConvertToInvokeResponse(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actual, _ := ConvertToInvokeResponse(tt.args.res, tt.args.tcs)
+			actual, _ := ConvertToInvokeResponse(tt.args.res, tt.args.tools)
 			assert.Equal(t, tt.expected, actual)
 		})
 	}

--- a/cli/serve.go
+++ b/cli/serve.go
@@ -96,7 +96,6 @@ var serveCmd = &cobra.Command{
 		if aiConfig != nil {
 			listener = mem.Listen()
 			// add AI connection middleware
-			options = append(options, yomo.WithZipperConnMiddleware(ai.RegisterFunctionMW()))
 			options = append(options, yomo.WithFrameListener(listener))
 		}
 		// new zipper

--- a/cli/test.go
+++ b/cli/test.go
@@ -166,30 +166,22 @@ var testPromptCmd = &cobra.Command{
 				continue
 			}
 			// tool calls
-			for tag, tcs := range invokeResp.ToolCalls {
-				toolCallCount := len(tcs)
-				if toolCallCount > 0 {
-					log.InfoStatusEvent(os.Stdout, "Invoking functions[%d]:", toolCallCount)
-					for _, tc := range tcs {
-						if invokeResp.ToolMessages == nil {
-							log.InfoStatusEvent(os.Stdout,
-								"\t[%s] tag: %d, name: %s, arguments: %s",
-								tc.ID,
-								tag,
-								tc.Function.Name,
-								tc.Function.Arguments,
-							)
-						} else {
-							log.InfoStatusEvent(os.Stdout,
-								"\t[%s] tag: %d, name: %s, arguments: %s\n🌟 result: %s",
-								tc.ID,
-								tag,
-								tc.Function.Name,
-								tc.Function.Arguments,
-								getToolCallResult(tc, invokeResp.ToolMessages),
-							)
-						}
-					}
+			for _, tc := range invokeResp.ToolCalls {
+				if invokeResp.ToolMessages == nil {
+					log.InfoStatusEvent(os.Stdout,
+						"\t[%s] name: %s, arguments: %s",
+						tc.ID,
+						tc.Function.Name,
+						tc.Function.Arguments,
+					)
+				} else {
+					log.InfoStatusEvent(os.Stdout,
+						"\t[%s] name: %s, arguments: %s\n🌟 result: %s",
+						tc.ID,
+						tc.Function.Name,
+						tc.Function.Arguments,
+						getToolCallResult(tc, invokeResp.ToolMessages),
+					)
 				}
 			}
 			// finish reason
@@ -211,7 +203,7 @@ var testPromptCmd = &cobra.Command{
 	},
 }
 
-func getToolCallResult(tc *openai.ToolCall, tms []ai.ToolMessage) string {
+func getToolCallResult(tc openai.ToolCall, tms []ai.ToolMessage) string {
 	result := ""
 	for _, tm := range tms {
 		if tm.ToolCallID == tc.ID {

--- a/core/context.go
+++ b/core/context.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"sync"
 
+	"github.com/yomorun/yomo/ai"
 	"github.com/yomorun/yomo/core/frame"
 	"github.com/yomorun/yomo/core/metadata"
 )
@@ -58,6 +59,11 @@ func newContext(conn *Connection, df *frame.DataFrame) (c *Context, err error) {
 	fmd, err := metadata.Decode(df.Metadata)
 	if err != nil {
 		return nil, err
+	}
+
+	// compatible with client propagate target bug
+	if df.Tag == ai.ReducerTag {
+		SetMetadataTarget(fmd, "")
 	}
 
 	// merge connection metadata.

--- a/core/metadata/metadata.go
+++ b/core/metadata/metadata.go
@@ -41,8 +41,13 @@ func (m M) Get(k string) (string, bool) {
 }
 
 // Set sets the value of the given key. if the key is empty, it will do nothing.
+// if value is empty, the key will be deleted.
 func (m M) Set(k, v string) {
 	if len(k) == 0 {
+		return
+	}
+	if len(v) == 0 {
+		delete(m, k)
 		return
 	}
 	m[k] = v

--- a/core/metadata/metadata_test.go
+++ b/core/metadata/metadata_test.go
@@ -27,7 +27,13 @@ func Test(t *testing.T) {
 		got, ok := md.Get("")
 		assert.False(t, ok)
 		assert.Equal(t, "", got)
+	})
 
+	t.Run("Set Empty Value", func(t *testing.T) {
+		md.Set("fff", "")
+		got, ok := md.Get("fff")
+		assert.False(t, ok)
+		assert.Equal(t, "", got)
 	})
 
 	t.Run("Range", func(t *testing.T) {

--- a/core/server.go
+++ b/core/server.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -18,6 +19,7 @@ import (
 
 	// authentication implements, Currently, only token authentication is implemented
 	_ "github.com/yomorun/yomo/pkg/auth"
+	"github.com/yomorun/yomo/pkg/bridge/ai/register"
 	"github.com/yomorun/yomo/pkg/frame-codec/y3codec"
 	yquic "github.com/yomorun/yomo/pkg/listener/quic"
 	pkgtls "github.com/yomorun/yomo/pkg/tls"
@@ -185,6 +187,7 @@ func (s *Server) handleFrameConn(fconn frame.Conn, logger *slog.Logger) {
 
 	if conn.ClientType() == ClientTypeStreamFunction {
 		s.router.Remove(conn.ID())
+		register.UnregisterFunction(conn.ID(), conn.Metadata())
 	}
 	_ = s.connector.Remove(conn.ID())
 }
@@ -246,9 +249,9 @@ func (s *Server) handshake(fconn frame.Conn) (*Connection, error) {
 			return nil, rejectHandshake(fconn, err)
 		}
 
-		// 5. store function definition to metadata
-		if hf.FunctionDefinition != nil {
-			conn.Metadata().Set(ai.FunctionDefinitionKey, string(hf.FunctionDefinition))
+		// 5. try register function definition to global
+		if err := s.tryRegisterFunctionDefinition(hf, conn, md); err != nil {
+			return nil, rejectHandshake(fconn, err)
 		}
 
 		// 6. add route rules
@@ -270,6 +273,22 @@ func tryUseFunctionNameAsTarget(hf *frame.HandshakeFrame) {
 		hf.WantedTarget = hf.Name
 		hf.ObserveDataTags = append(hf.ObserveDataTags, ai.FunctionCallTag)
 	}
+}
+
+func (s *Server) tryRegisterFunctionDefinition(hf *frame.HandshakeFrame, conn *Connection, md metadata.M) error {
+	definition := hf.FunctionDefinition
+	if definition == nil {
+		return nil
+	}
+	fd := ai.FunctionDefinition{}
+	if err := json.Unmarshal([]byte(definition), &fd); err != nil {
+		return fmt.Errorf("unmarshal function definition error: %s", err.Error())
+	}
+	if err := register.RegisterFunction(&fd, conn.ID(), md); err != nil {
+		return err
+	}
+	s.logger.Info("register ai function success", "function_name", fd.Name, "definition", string(definition))
+	return nil
 }
 
 func (s *Server) handleConn(conn *Connection) {

--- a/pkg/bridge/ai/ai.go
+++ b/pkg/bridge/ai/ai.go
@@ -45,21 +45,19 @@ func registerFunction(r register.Register) core.ConnMiddleware {
 				return
 			}
 
-			for _, tag := range conn.ObserveDataTags() {
-				// register ai function
-				fd := ai.FunctionDefinition{}
-				err := json.Unmarshal([]byte(definition), &fd)
-				if err != nil {
-					conn.Logger.Error("unmarshal function definition", "err", err)
-					return
-				}
-				err = r.RegisterFunction(tag, &fd, conn.ID(), connMd)
-				if err != nil {
-					conn.Logger.Error("failed to register ai function", "name", conn.Name(), "tag", tag, "err", err)
-					return
-				}
-				conn.Logger.Info("register ai function success", "name", conn.Name(), "tag", tag, "definition", string(definition))
+			// register ai function
+			fd := ai.FunctionDefinition{}
+			err := json.Unmarshal([]byte(definition), &fd)
+			if err != nil {
+				conn.Logger.Error("unmarshal function definition", "err", err)
+				return
 			}
+			err = r.RegisterFunction(&fd, conn.ID(), connMd)
+			if err != nil {
+				conn.Logger.Error("failed to register ai function", "name", conn.Name(), "err", err)
+				return
+			}
+			conn.Logger.Info("register ai function success", "name", conn.Name(), "definition", string(definition))
 		}
 	})
 }

--- a/pkg/bridge/ai/ai_test.go
+++ b/pkg/bridge/ai/ai_test.go
@@ -23,7 +23,7 @@ func TestRegisterFunction(t *testing.T) {
 		connHandler(conn)
 
 		toolCalls, _ := r.ListToolCalls(conn.Metadata())
-		assert.Equal(t, map[uint32]openai.Tool{}, toolCalls)
+		assert.Equal(t, []openai.Tool{}, toolCalls)
 	})
 
 	t.Run("stream function", func(t *testing.T) {
@@ -32,8 +32,8 @@ func TestRegisterFunction(t *testing.T) {
 
 		toolCalls, _ := r.ListToolCalls(conn.Metadata())
 
-		want := map[uint32]openai.Tool{
-			0x33: {Type: "function", Function: &openai.FunctionDefinition{Name: "sfn"}},
+		want := []openai.Tool{
+			{Type: "function", Function: &openai.FunctionDefinition{Name: "sfn"}},
 		}
 
 		assert.Equal(t, want, toolCalls)

--- a/pkg/bridge/ai/ai_test.go
+++ b/pkg/bridge/ai/ai_test.go
@@ -1,44 +1,10 @@
 package ai
 
 import (
-	"fmt"
 	"testing"
 
-	openai "github.com/sashabaranov/go-openai"
 	"github.com/stretchr/testify/assert"
-	"github.com/yomorun/yomo/ai"
-	"github.com/yomorun/yomo/core"
-	"github.com/yomorun/yomo/core/frame"
-	"github.com/yomorun/yomo/core/metadata"
-	"github.com/yomorun/yomo/core/ylog"
-	"github.com/yomorun/yomo/pkg/bridge/ai/register"
 )
-
-func TestRegisterFunction(t *testing.T) {
-	r := register.NewDefault()
-	connHandler := registerFunction(r)(func(c *core.Connection) {})
-
-	t.Run("source", func(t *testing.T) {
-		conn := mockSourceConn(1, "source")
-		connHandler(conn)
-
-		toolCalls, _ := r.ListToolCalls(conn.Metadata())
-		assert.Equal(t, []openai.Tool{}, toolCalls)
-	})
-
-	t.Run("stream function", func(t *testing.T) {
-		conn := mockSfnConn(2, "sfn")
-		connHandler(conn)
-
-		toolCalls, _ := r.ListToolCalls(conn.Metadata())
-
-		want := []openai.Tool{
-			{Type: "function", Function: &openai.FunctionDefinition{Name: "sfn"}},
-		}
-
-		assert.Equal(t, want, toolCalls)
-	})
-}
 
 func TestParseZipperAddr(t *testing.T) {
 	tests := []struct {
@@ -153,15 +119,4 @@ func TestParseConfig(t *testing.T) {
 			}
 		})
 	}
-}
-
-func mockSfnConn(id uint64, name string) *core.Connection {
-	md := metadata.M{
-		ai.FunctionDefinitionKey: fmt.Sprintf(`{"name": "%s"}`, name),
-	}
-	return core.NewConnection(id, name, "mock-sfn-id", core.ClientTypeStreamFunction, md, []frame.Tag{0x33}, nil, ylog.Default())
-}
-
-func mockSourceConn(id uint64, name string) *core.Connection {
-	return core.NewConnection(id, name, "mock-source-id", core.ClientTypeSource, metadata.New(), []frame.Tag{0x33}, nil, ylog.Default())
 }

--- a/pkg/bridge/ai/api_server.go
+++ b/pkg/bridge/ai/api_server.go
@@ -173,15 +173,15 @@ func NewHandler(service *Service) *Handler {
 func (h *Handler) HandleOverview(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
-	tcs, err := register.ListToolCalls(FromCallerContext(r.Context()).Metadata())
+	tools, err := register.ListToolCalls(FromCallerContext(r.Context()).Metadata())
 	if err != nil {
 		RespondWithError(w, http.StatusInternalServerError, err, h.service.logger)
 		return
 	}
 
-	functions := make([]*openai.FunctionDefinition, len(tcs))
-	for tag, tc := range tcs {
-		functions[tag] = tc.Function
+	functions := make([]*openai.FunctionDefinition, len(tools))
+	for i, tc := range tools {
+		functions[i] = tc.Function
 	}
 
 	json.NewEncoder(w).Encode(&ai.OverviewResponse{Functions: functions})

--- a/pkg/bridge/ai/api_server.go
+++ b/pkg/bridge/ai/api_server.go
@@ -179,7 +179,7 @@ func (h *Handler) HandleOverview(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	functions := make(map[uint32]*openai.FunctionDefinition)
+	functions := make([]*openai.FunctionDefinition, len(tcs))
 	for tag, tc := range tcs {
 		functions[tag] = tc.Function
 	}

--- a/pkg/bridge/ai/api_server_test.go
+++ b/pkg/bridge/ai/api_server_test.go
@@ -32,7 +32,7 @@ func TestServer(t *testing.T) {
 		},
 	}
 	register.SetRegister(register.NewDefault())
-	register.RegisterFunction(100, functionDefinition, 200, nil)
+	register.RegisterFunction(functionDefinition, 200, nil)
 
 	// mock the provider and the req/res of the caller
 	pd, err := provider.NewMock("mock provider", provider.MockChatCompletionResponse(stopResp, stopResp))
@@ -72,7 +72,7 @@ func TestServer(t *testing.T) {
 		assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
 
 		body, _ := io.ReadAll(resp.Body)
-		assert.Equal(t, `{"Functions":{"100":{"name":"function1","description":"desc1","parameters":{"type":"type1","properties":{"prop1":{"type":"type1","description":"desc1"},"prop2":{"type":"type2","description":"desc2"}},"required":["prop1"]}}}}
+		assert.Equal(t, `{"Functions":[{"name":"function1","description":"desc1","parameters":{"type":"type1","properties":{"prop1":{"type":"type1","description":"desc1"},"prop2":{"type":"type2","description":"desc2"}},"required":["prop1"]}}]}
 `, string(body))
 	})
 

--- a/pkg/bridge/ai/call_syncer_test.go
+++ b/pkg/bridge/ai/call_syncer_test.go
@@ -15,11 +15,11 @@ import (
 	"github.com/yomorun/yomo/serverless/mock"
 )
 
-var testdata = map[uint32][]*openai.ToolCall{
-	1: {{ID: "tool-call-id-1", Function: openai.FunctionCall{Name: "function-1"}}},
-	2: {{ID: "tool-call-id-2", Function: openai.FunctionCall{Name: "function-2"}}},
-	3: {{ID: "tool-call-id-3", Function: openai.FunctionCall{Name: "function-3"}}},
-	4: {{ID: "tool-call-id-4", Function: openai.FunctionCall{Name: "function-4"}}},
+var testdata = []openai.ToolCall{
+	{ID: "tool-call-id-1", Function: openai.FunctionCall{Name: "function-1"}},
+	{ID: "tool-call-id-2", Function: openai.FunctionCall{Name: "function-2"}},
+	{ID: "tool-call-id-3", Function: openai.FunctionCall{Name: "function-3"}},
+	{ID: "tool-call-id-4", Function: openai.FunctionCall{Name: "function-4"}},
 }
 
 func TestTimeoutCallSyncer(t *testing.T) {
@@ -46,8 +46,8 @@ func TestTimeoutCallSyncer(t *testing.T) {
 		},
 	}
 
-	got, _ := syncer.Call(context.TODO(), transID, reqID, map[uint32][]*openai.ToolCall{
-		1: {{ID: "tool-call-id", Function: openai.FunctionCall{Name: "timeout-function"}}},
+	got, _ := syncer.Call(context.TODO(), transID, reqID, []openai.ToolCall{
+		{ID: "tool-call-id", Function: openai.FunctionCall{Name: "timeout-function"}},
 	})
 
 	assert.ElementsMatch(t, want, got)
@@ -133,6 +133,11 @@ func (t *mockDataFlow) Write(tag uint32, data []byte) error {
 	return nil
 }
 
+func (t *mockDataFlow) WriteWithTarget(tag uint32, data []byte, target string) error {
+	t.wrCh <- mock.NewMockContext(data, tag)
+	return nil
+}
+
 func (t *mockDataFlow) SetHandler(fn core.AsyncHandler) error {
 	t.reducer = fn
 	return nil
@@ -161,4 +166,3 @@ func (t *mockDataFlow) SetPipeHandler(fn core.PipeHandler) error              { 
 func (t *mockDataFlow) SetWantedTarget(string)                                { panic("unimplemented") }
 func (t *mockDataFlow) Wait()                                                 { panic("unimplemented") }
 func (t *mockDataFlow) SetErrorHandler(fn func(err error))                    { panic("unimplemented") }
-func (t *mockDataFlow) WriteWithTarget(_ uint32, _ []byte, _ string) error    { panic("unimplemented") }

--- a/pkg/bridge/ai/caller.go
+++ b/pkg/bridge/ai/caller.go
@@ -53,17 +53,17 @@ func NewCaller(source yomo.Source, reducer yomo.StreamFunction, md metadata.M, c
 
 // sourceWriteToChan makes source write data to the channel.
 // The TagFunctionCall objects are continuously be received from the channel and be sent by the source.
-func sourceWriteToChan(source yomo.Source, logger *slog.Logger) (chan<- TagFunctionCall, error) {
+func sourceWriteToChan(source yomo.Source, logger *slog.Logger) (chan<- ai.FunctionCall, error) {
 	err := source.Connect()
 	if err != nil {
 		return nil, err
 	}
 
-	ch := make(chan TagFunctionCall)
+	ch := make(chan ai.FunctionCall)
 	go func() {
 		for c := range ch {
-			buf, _ := c.FunctionCall.Bytes()
-			if err := source.Write(c.Tag, buf); err != nil {
+			buf, _ := c.Bytes()
+			if err := source.WriteWithTarget(ai.FunctionCallTag, buf, c.FunctionName); err != nil {
 				logger.Error("send data to zipper", "err", err.Error())
 			}
 		}

--- a/pkg/bridge/ai/register/register.go
+++ b/pkg/bridge/ai/register/register.go
@@ -85,7 +85,7 @@ func (r *register) RegisterFunction(fd *ai.FunctionDefinition, connID uint64, md
 	r.underlying.Range(func(_, value any) bool {
 		tool := value.(openai.Tool)
 		if tool.Function.Name == fd.Name {
-			err = fmt.Errorf("function %s already registered", fd.Name)
+			err = fmt.Errorf("function `%s` already registered", fd.Name)
 			return false
 		}
 		return true

--- a/pkg/bridge/ai/register/register.go
+++ b/pkg/bridge/ai/register/register.go
@@ -2,6 +2,7 @@
 package register
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/sashabaranov/go-openai"
@@ -39,13 +40,13 @@ func NewDefault() Register {
 }
 
 // ListToolCalls returns the list of tool calls
-func ListToolCalls(md metadata.M) (map[uint32]openai.Tool, error) {
+func ListToolCalls(md metadata.M) ([]openai.Tool, error) {
 	return defaultRegister.ListToolCalls(md)
 }
 
 // RegisterFunction registers a function calling function
-func RegisterFunction(tag uint32, functionDefinition *openai.FunctionDefinition, connID uint64, md metadata.M) error {
-	return defaultRegister.RegisterFunction(tag, functionDefinition, connID, md)
+func RegisterFunction(functionDefinition *openai.FunctionDefinition, connID uint64, md metadata.M) error {
+	return defaultRegister.RegisterFunction(functionDefinition, connID, md)
 }
 
 // UnregisterFunction unregisters a function calling function
@@ -53,18 +54,12 @@ func UnregisterFunction(connID uint64, md metadata.M) {
 	defaultRegister.UnregisterFunction(connID, md)
 }
 
-type connectedFn struct {
-	connID uint64
-	tag    uint32
-	tools  openai.Tool
-}
-
 // Register provides an stateful register for registering and unregistering functions
 type Register interface {
 	// ListToolCalls returns the list of tool calls
-	ListToolCalls(md metadata.M) (map[uint32]openai.Tool, error)
+	ListToolCalls(md metadata.M) ([]openai.Tool, error)
 	// RegisterFunction registers a function calling function
-	RegisterFunction(tag uint32, functionDefinition *openai.FunctionDefinition, connID uint64, md metadata.M) error
+	RegisterFunction(fd *openai.FunctionDefinition, connID uint64, md metadata.M) error
 	// UnregisterFunction unregisters a function calling function
 	UnregisterFunction(connID uint64, md metadata.M)
 }
@@ -73,26 +68,34 @@ type register struct {
 	underlying sync.Map
 }
 
-func (r *register) ListToolCalls(md metadata.M) (map[uint32]openai.Tool, error) {
-	result := make(map[uint32]openai.Tool)
+func (r *register) ListToolCalls(_ metadata.M) ([]openai.Tool, error) {
+	result := []openai.Tool{}
 
 	r.underlying.Range(func(_, value any) bool {
-		fn := value.(*connectedFn)
-		result[fn.tag] = fn.tools
+		tool := value.(openai.Tool)
+		result = append(result, tool)
 		return true
 	})
 
 	return result, nil
 }
 
-func (r *register) RegisterFunction(tag uint32, functionDefinition *ai.FunctionDefinition, connID uint64, md metadata.M) error {
-	r.underlying.Store(connID, &connectedFn{
-		connID: connID,
-		tag:    tag,
-		tools: openai.Tool{
-			Type:     openai.ToolTypeFunction,
-			Function: functionDefinition,
-		},
+func (r *register) RegisterFunction(fd *ai.FunctionDefinition, connID uint64, md metadata.M) error {
+	var err error
+	r.underlying.Range(func(_, value any) bool {
+		tool := value.(openai.Tool)
+		if tool.Function.Name == fd.Name {
+			err = fmt.Errorf("function %s already registered", fd.Name)
+			return false
+		}
+		return true
+	})
+	if err != nil {
+		return err
+	}
+	r.underlying.Store(connID, openai.Tool{
+		Function: fd,
+		Type:     openai.ToolTypeFunction,
 	})
 
 	return nil

--- a/pkg/bridge/ai/register/register_test.go
+++ b/pkg/bridge/ai/register/register_test.go
@@ -30,7 +30,7 @@ func TestRegister(t *testing.T) {
 	assert.NoError(t, err)
 
 	gotErr := RegisterFunction(functionDefinition, 2, nil)
-	assert.EqualError(t, gotErr, "function function1 already registered")
+	assert.EqualError(t, gotErr, "function `function1` already registered")
 
 	toolCalls, err := ListToolCalls(nil)
 	assert.NoError(t, err)

--- a/pkg/bridge/ai/register/register_test.go
+++ b/pkg/bridge/ai/register/register_test.go
@@ -3,7 +3,6 @@ package register
 import (
 	"testing"
 
-	"github.com/sashabaranov/go-openai"
 	"github.com/stretchr/testify/assert"
 	"github.com/yomorun/yomo/ai"
 )
@@ -27,28 +26,19 @@ func TestRegister(t *testing.T) {
 		},
 	}
 
-	err := RegisterFunction(1, functionDefinition, 1, nil)
+	err := RegisterFunction(functionDefinition, 1, nil)
 	assert.NoError(t, err)
+
+	gotErr := RegisterFunction(functionDefinition, 2, nil)
+	assert.EqualError(t, gotErr, "function function1 already registered")
 
 	toolCalls, err := ListToolCalls(nil)
 	assert.NoError(t, err)
-	assertToolCalls(t, 1, functionDefinition, toolCalls)
+	assert.Equal(t, functionDefinition.Name, toolCalls[0].Function.Name)
+	assert.Equal(t, functionDefinition.Description, toolCalls[0].Function.Description)
 
 	UnregisterFunction(1, nil)
 	toolCalls, err = ListToolCalls(nil)
 	assert.NoError(t, err)
-	assertToolCalls(t, 0, nil, toolCalls)
-}
-
-func assertToolCalls(t *testing.T, wantTag uint32, want *ai.FunctionDefinition, toolCalls map[uint32]openai.Tool) {
-	var (
-		tag uint32
-		got openai.Tool
-	)
-	for k, v := range toolCalls {
-		tag = k
-		got = v
-	}
-	assert.Equal(t, wantTag, tag)
-	assert.Equal(t, want, got.Function)
+	assert.Zero(t, len(toolCalls))
 }

--- a/sfn.go
+++ b/sfn.go
@@ -242,6 +242,9 @@ func (s *streamFunction) onDataFrame(dataFrame *frame.DataFrame) {
 				return
 			}
 
+			// do not propagate target
+			core.SetMetadataTarget(md, "")
+
 			// add trace
 			tracer := trace.NewTracer("StreamFunction", s.client.DisableOtelTrace())
 			span := tracer.Start(md, s.name)


### PR DESCRIPTION
# Description

This commit is fully compatible with the previous version of the client.

Processing Flow:

1. `sfn` Connects to zipper.
2. When `sfn` connects to `zipper`, `zipper` checks if the `HandshakeFrame` contains a function definition.
3. If it exists, the current `sfn` is identified as an `llm-sfn`.
4. Subsequently, zipper makes the `llm-sfn` observes `FunctionCallTag` and sets FunctionName to `WantedTarget`.
5. When bridge server triggers function calling to invoke `llm-sfn`, `bridge-source` sends data in the format `tag=FunctionCallTag&&target=FunctionName`.
6. `llm-sfn` Processes and Returns Results
7. After receiving the arguments data, `llm-sfn` processes it and writes the results to `tag=ReducerTag`. Subsequently, `bridge-reducer` observes this function calling result.

## Impact

1. Simplified `llm-sfn` Coding，manual definition of tags is no longer required, reducing the learning curve for users.
2. llm bridge no longer supports registering `llm-sfn` with duplicate names

