### PR TITLE
feat(llm-bridge): support tools params

### DIFF
--- a/pkg/bridge/ai/call_syncer.go
+++ b/pkg/bridge/ai/call_syncer.go
@@ -82,6 +82,9 @@ type toolOut struct {
 }
 
 func (f *callSyncer) Call(ctx context.Context, transID, reqID string, toolCalls []openai.ToolCall) ([]ToolCallResult, error) {
+	if len(toolCalls) == 0 {
+		return []ToolCallResult{}, nil
+	}
 	defer func() {
 		f.cleanCh <- reqID
 	}()


### PR DESCRIPTION
If the user provides `tools` parameters through tools, the LLM Bridge will not invoke llm-sfn.