### PR TITLE
feat(llm-bridge): supports to intercept error for responding

### DIFF
--- a/pkg/bridge/ai/api_server_test.go
+++ b/pkg/bridge/ai/api_server_test.go
@@ -121,6 +121,6 @@ func TestServer(t *testing.T) {
 		assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
 
 		body, _ := io.ReadAll(resp.Body)
-		assert.Equal(t, "{\"error\":{\"code\":\"400\",\"message\":\"invalid character 's' looking for beginning of value\"}}", string(body))
+		assert.Equal(t, "{\"error\":{\"code\":\"invalid_request_error\",\"message\":\"Invalid request: invalid character 's' looking for beginning of value\"}}\n", string(body))
 	})
 }

--- a/pkg/bridge/ai/response_writer_test.go
+++ b/pkg/bridge/ai/response_writer_test.go
@@ -6,12 +6,13 @@ import (
 
 	"github.com/sashabaranov/go-openai"
 	"github.com/stretchr/testify/assert"
+	"github.com/yomorun/yomo/core/ylog"
 )
 
 func TestResponseWriter(t *testing.T) {
 	recorder := httptest.NewRecorder()
 
-	w := NewResponseWriter(recorder)
+	w := NewResponseWriter(recorder, ylog.NewFromConfig(ylog.Config{}))
 
 	h := w.SetStreamHeader()
 

--- a/pkg/bridge/ai/service_test.go
+++ b/pkg/bridge/ai/service_test.go
@@ -399,7 +399,7 @@ func TestServiceChatCompletion(t *testing.T) {
 			caller.SetSystemPrompt(tt.args.systemPrompt, SystemPromptOpOverwrite)
 
 			w := httptest.NewRecorder()
-			err = service.GetChatCompletions(context.TODO(), tt.args.request, "transID", caller, NewResponseWriter(w), nil)
+			err = service.GetChatCompletions(context.TODO(), tt.args.request, "transID", caller, NewResponseWriter(w, slog.Default()), nil)
 			assert.NoError(t, err)
 
 			assert.Equal(t, tt.wantRequest, pd.RequestRecords())


### PR DESCRIPTION
# Description

1. Remove the global trace client. Reinitialize it if you want to use a trace client.
2. add `InterceptError(code int, err error)` function for `EventWriter` to intercept errors and send error messages back to the client.
