### PR TITLE
feat(cli): yomo init default to nodejs serverless and try bun at first

### DIFF
--- a/cli/init.go
+++ b/cli/init.go
@@ -103,5 +103,5 @@ func init() {
 	rootCmd.AddCommand(initCmd)
 
 	initCmd.Flags().StringVarP(&sfnType, "type", "t", "llm", "The type of Stream Function, support normal and llm")
-	initCmd.Flags().StringVarP(&lang, "lang", "l", "go", "The language of Stream Function, support go and node")
+	initCmd.Flags().StringVarP(&lang, "lang", "l", "node", "The language of Stream Function, support go and node")
 }

--- a/cli/init.go
+++ b/cli/init.go
@@ -37,8 +37,8 @@ var (
 // initCmd represents the init command
 var initCmd = &cobra.Command{
 	Use:   "init <app_name>",
-	Short: "Initialize a YoMo Stream function",
-	Long:  "Initialize a YoMo Stream function",
+	Short: "Initialize a YoMo Serverless LLM Function",
+	Long:  "Initialize a YoMo Serverless LLM Function",
 	Run: func(cmd *cobra.Command, args []string) {
 		name := ""
 		if len(args) >= 1 && args[0] != "" {
@@ -46,10 +46,10 @@ var initCmd = &cobra.Command{
 			opts.Name = name
 		}
 		if name == "" {
-			log.FailureStatusEvent(os.Stdout, "Please input your app name, e.g. `yomo init my-app [-l go -t llm]`")
+			log.FailureStatusEvent(os.Stdout, "Please input your app name, e.g. `yomo init my-app [-l node -t llm]`")
 			return
 		}
-		log.PendingStatusEvent(os.Stdout, "Initializing the Stream Function...")
+		log.PendingStatusEvent(os.Stdout, "Initializing the Serverless LLM Function...")
 		name = strings.ReplaceAll(name, " ", "_")
 
 		filename := filepath.Join(name, DefaultSFNSourceFile(lang))
@@ -69,7 +69,7 @@ var initCmd = &cobra.Command{
 			return
 		}
 		if err := file.PutContents(fname, contentTmpl); err != nil {
-			log.FailureStatusEvent(os.Stdout, "Write stream function into %s file failure with the error: %v", fname, err)
+			log.FailureStatusEvent(os.Stdout, "Write Serverless LLM Function into %s file failure with the error: %v", fname, err)
 			return
 		}
 		// create app test file
@@ -89,12 +89,12 @@ var initCmd = &cobra.Command{
 		// create .env
 		fname = filepath.Join(name, ".env")
 		if err := file.PutContents(fname, []byte(fmt.Sprintf("YOMO_SFN_NAME=%s\nYOMO_SFN_ZIPPER=localhost:9000\n", name))); err != nil {
-			log.FailureStatusEvent(os.Stdout, "Write stream function .env file failure with the error: %v", err)
+			log.FailureStatusEvent(os.Stdout, "Write Serverless LLM Function .env file failure with the error: %v", err)
 			return
 		}
 
-		log.SuccessStatusEvent(os.Stdout, "Congratulations! You have initialized the stream function successfully.")
-		log.InfoStatusEvent(os.Stdout, "You can enjoy the YoMo Stream Function via the command: ")
+		log.SuccessStatusEvent(os.Stdout, "Congratulations! You have initialized the Serverless LLM Function successfully.")
+		log.InfoStatusEvent(os.Stdout, "You can enjoy the YoMo Serverless LLM Function via the command: ")
 		log.InfoStatusEvent(os.Stdout, "\tcd %s && yomo run", name)
 	},
 }
@@ -102,6 +102,6 @@ var initCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(initCmd)
 
-	initCmd.Flags().StringVarP(&sfnType, "type", "t", "llm", "The type of Stream Function, support normal and llm")
-	initCmd.Flags().StringVarP(&lang, "lang", "l", "node", "The language of Stream Function, support go and node")
+	initCmd.Flags().StringVarP(&sfnType, "type", "t", "llm", "The type of Serverless LLM Function, support normal and llm")
+	initCmd.Flags().StringVarP(&lang, "lang", "l", "node", "The language of Serverless LLM Function, support go and node")
 }

--- a/cli/run.go
+++ b/cli/run.go
@@ -33,8 +33,8 @@ import (
 // runCmd represents the run command
 var runCmd = &cobra.Command{
 	Use:   "run [flags] sfn",
-	Short: "Run a YoMo Stream Function",
-	Long:  "Run a YoMo Stream Function",
+	Short: "Run a YoMo Serverless LLM Function",
+	Long:  "Run a YoMo Serverless LLM Function",
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := parseFileArg(args, &opts, defaultSFNCompliedFile, defaultSFNWASIFile, defaultSFNSourceFile, defaultSFNSourceTSFile); err != nil {
 			log.FailureStatusEvent(os.Stdout, "%s", err.Error())
@@ -42,13 +42,13 @@ var runCmd = &cobra.Command{
 		}
 		loadOptionsFromViper(viper.RunViper, &opts)
 		// Serverless
-		log.InfoStatusEvent(os.Stdout, "YoMo Stream Function file: %v", opts.Filename)
+		log.InfoStatusEvent(os.Stdout, "YoMo Serverless LLM Function file: %v", opts.Filename)
 		if opts.Name == "" {
-			log.FailureStatusEvent(os.Stdout, "YoMo Stream Function's Name is empty, please set name used by `-n` flag")
+			log.FailureStatusEvent(os.Stdout, "YoMo Serverless LLM Function's Name is empty, please set name used by `-n` flag")
 			return
 		}
 		// resolve serverless
-		log.PendingStatusEvent(os.Stdout, "Creating YoMo Stream Function instance...")
+		log.PendingStatusEvent(os.Stdout, "Creating YoMo Serverless LLM Function instance...")
 		if err := parseZipperAddr(&opts); err != nil {
 			log.FailureStatusEvent(os.Stdout, "%s", err.Error())
 			return
@@ -75,10 +75,10 @@ var runCmd = &cobra.Command{
 
 		log.InfoStatusEvent(
 			os.Stdout,
-			"Starting YoMo Stream Function instance, connecting to zipper: %v",
+			"Starting YoMo Serverless LLM Function instance, connecting to zipper: %v",
 			opts.ZipperAddr,
 		)
-		log.InfoStatusEvent(os.Stdout, "Stream Function is running...")
+		log.InfoStatusEvent(os.Stdout, "Serverless LLM Function is running...")
 		if err := s.Run(verbose); err != nil {
 			log.FailureStatusEvent(os.Stdout, "%s", err.Error())
 			return
@@ -90,7 +90,7 @@ func init() {
 	rootCmd.AddCommand(runCmd)
 
 	runCmd.Flags().StringVarP(&opts.ZipperAddr, "zipper", "z", "localhost:9000", "YoMo-Zipper endpoint addr")
-	runCmd.Flags().StringVarP(&opts.Name, "name", "n", "", "yomo stream function name.")
+	runCmd.Flags().StringVarP(&opts.Name, "name", "n", "", "yomo Serverless LLM Function name.")
 	runCmd.Flags().StringVarP(&opts.ModFile, "modfile", "m", "", "custom go.mod")
 	runCmd.Flags().StringVarP(&opts.Credential, "credential", "d", "", "client credential payload, eg: `token:dBbBiRE7`")
 	runCmd.Flags().StringVarP(&opts.Runtime, "runtime", "r", "", "serverless runtime type")

--- a/cli/serverless/nodejs/runtime.go
+++ b/cli/serverless/nodejs/runtime.go
@@ -274,5 +274,14 @@ func (w *NodejsWrapper) InstallDeps() error {
 	if err != nil {
 		return fmt.Errorf("run %s failed: %v", cmd.String(), err)
 	}
+	// add .gitignore file, and ignore node_modules/, dist/, .wrapper.ts
+	gitignore := filepath.Join(w.workDir, ".gitignore")
+	if _, err := os.Stat(gitignore); os.IsNotExist(err) {
+		err = os.WriteFile(gitignore, []byte("node_modules/\ndist/\n.wrapper.ts\n"), 0644)
+		if err != nil {
+			return fmt.Errorf("write .gitignore failed: %v", err)
+		}
+	}
+
 	return nil
 }

--- a/cli/serverless/nodejs/runtime.go
+++ b/cli/serverless/nodejs/runtime.go
@@ -29,6 +29,7 @@ type NodejsWrapper struct {
 	entryTSFile  string // eg. src/app.ts
 	entryJSFile  string // eg. src/app.js
 	fileName     string // eg. src/app
+	outputDir    string // eg. dist/
 
 	// command path
 	nodePath string
@@ -37,25 +38,36 @@ type NodejsWrapper struct {
 
 // NewWrapper returns a new NodejsWrapper
 func NewWrapper(functionName, entryTSFile string) (*NodejsWrapper, error) {
-	// check command
+	// check node
 	nodePath, err := exec.LookPath("node")
 	if err != nil {
-		return nil, errors.New("[node] command was not found. to run the sfn in ts, you need to install node. For details, visit https://nodejs.org")
+		return nil, errors.New("the Node.js runtime is not found. To run TypeScript serverless functions, please install Node.js from https://nodejs.org")
 	}
+
+	// prefer pnpm, if pnpm is not found, fallback to npm
 	npmPath, err := exec.LookPath("pnpm")
 	if err != nil {
 		npmPath, _ = exec.LookPath("npm")
 	}
 
+	// check entry file
 	ext := filepath.Ext(entryTSFile)
 	if ext != ".ts" {
-		return nil, fmt.Errorf("only support typescript, got: %s", entryTSFile)
+		return nil, fmt.Errorf("this runtime only supports Typescript files (.ts), got: %s", entryTSFile)
 	}
-	workdir := filepath.Dir(entryTSFile)
 
+	// set workdir
+	// workdir := filepath.Dir(entryTSFile)
+	workdir := "./"
+
+	// set output dir
+	outputDir := filepath.Join(workdir, "dist")
+
+	// the compiled js file
 	entryJSFile := entryTSFile[:len(entryTSFile)-len(ext)] + ".js"
 
-	fileName := entryTSFile[:len(entryTSFile)-len(filepath.Ext(entryTSFile))]
+	// the file name without extension
+	fileName := entryTSFile[:len(entryTSFile)-len(ext)]
 
 	w := &NodejsWrapper{
 		functionName: functionName,
@@ -65,6 +77,7 @@ func NewWrapper(functionName, entryTSFile string) (*NodejsWrapper, error) {
 		fileName:     fileName,
 		nodePath:     nodePath,
 		npmPath:      npmPath,
+		outputDir:    outputDir,
 	}
 
 	return w, nil
@@ -75,7 +88,7 @@ func (w *NodejsWrapper) WorkDir() string {
 	return w.workDir
 }
 
-// Build defines how to build the serverless function.
+// Build defines how to build the serverless llm function.
 func (w *NodejsWrapper) Build(env []string) error {
 	// 1. generate .wrapper.ts file
 	dstPath := filepath.Join(w.workDir, wrapperTS)
@@ -99,7 +112,7 @@ func (w *NodejsWrapper) Build(env []string) error {
 	tsconfigPath := filepath.Join(w.workDir, "tsconfig.json")
 	if _, err := os.Stat(tsconfigPath); os.IsNotExist(err) {
 		// not exist, create it using tsc --init
-		cmdTSCInit := exec.Command("tsc", "--init")
+		cmdTSCInit := exec.Command("tsc", "--init", "--outDir", "./dist")
 		cmdTSCInit.Dir = w.workDir
 		cmdTSCInit.Stdout = os.Stdout
 		cmdTSCInit.Stderr = os.Stderr
@@ -162,7 +175,7 @@ func (w *NodejsWrapper) Build(env []string) error {
 
 // Run runs the serverless function
 func (w *NodejsWrapper) Run(env []string) error {
-	cmd := exec.Command(w.nodePath, wrapperJS)
+	cmd := exec.Command(w.nodePath, filepath.Join(w.outputDir, wrapperJS))
 	cmd.Dir = w.workDir
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -172,6 +185,9 @@ func (w *NodejsWrapper) Run(env []string) error {
 }
 
 func (w *NodejsWrapper) genWrapperTS(functionName, dstPath string) error {
+	baseFilename := w.workDir + filepath.Base(w.fileName)
+	entryTS := baseFilename + ".ts"
+
 	data := struct {
 		WorkDir      string
 		FunctionName string
@@ -180,8 +196,8 @@ func (w *NodejsWrapper) genWrapperTS(functionName, dstPath string) error {
 	}{
 		WorkDir:      w.workDir,
 		FunctionName: functionName,
-		FileName:     w.fileName,
-		FilePath:     w.entryTSFile,
+		FileName:     baseFilename,
+		FilePath:     entryTS,
 	}
 
 	dst, err := os.OpenFile(dstPath, os.O_WRONLY|os.O_CREATE, 0755)

--- a/cli/serverless/nodejs/runtime.go
+++ b/cli/serverless/nodejs/runtime.go
@@ -58,8 +58,7 @@ func NewWrapper(functionName, entryTSFile string) (*NodejsWrapper, error) {
 	}
 
 	// set workdir
-	// workdir := filepath.Dir(entryTSFile)
-	workdir := "./"
+	workdir := filepath.Dir(entryTSFile)
 
 	// set output dir
 	outputDir := filepath.Join(workdir, "dist")
@@ -196,8 +195,6 @@ func (w *NodejsWrapper) Run(env []string) error {
 		cmd.Env = env
 
 		return cmd.Run()
-	} else {
-		log.Println("Bun is not installed, check Nodejs")
 	}
 
 	// if bun is not found, fallback to nodejs
@@ -211,7 +208,7 @@ func (w *NodejsWrapper) Run(env []string) error {
 }
 
 func (w *NodejsWrapper) genWrapperTS(functionName, dstPath string) error {
-	baseFilename := w.workDir + filepath.Base(w.fileName)
+	baseFilename := "./" + filepath.Base(w.fileName)
 	entryTS := baseFilename + ".ts"
 
 	data := struct {
@@ -220,7 +217,7 @@ func (w *NodejsWrapper) genWrapperTS(functionName, dstPath string) error {
 		FileName     string
 		FilePath     string
 	}{
-		WorkDir:      w.workDir,
+		WorkDir:      "./",
 		FunctionName: functionName,
 		FileName:     baseFilename,
 		FilePath:     entryTS,


### PR DESCRIPTION
generate typescript app by default when `yomo init`:

```sh
yomo init my-llm-function-calling
```

and, if `Bunjs` exist, use it, otherwise, fallback to nodejs.

and introduce `./dist` directory for `yomo run app.ts`, modify imports in `.wrapper.ts` to relative path.

at last, `yomo init` will create `.gitignore` file.