### PR TITLE
fix: unmarshal response_format=json_schema bug

### DIFF
--- a/ai/openai.go
+++ b/ai/openai.go
@@ -1,6 +1,7 @@
 package ai
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -56,4 +57,40 @@ func ConvertToInvokeResponse(res *openai.ChatCompletionResponse, tools []openai.
 	}
 
 	return result, nil
+}
+
+// DecodeChatCompletionRequest decodes openai.ChatCompletionRequest from JSON data.
+// If a response_format is present, we cannot directly unmarshal it as a ChatCompletionRequest
+// because the schema field is a json.Unmarshaler.
+// Therefore, we need to use a temporary tmpRequest to unmarshal it.
+func DecodeChatCompletionRequest(data []byte) (req openai.ChatCompletionRequest, err error) {
+	type tmpRequest struct {
+		openai.ChatCompletionRequest
+		ResponseFormat *struct {
+			*openai.ChatCompletionResponseFormat
+			JSONSchema *struct {
+				*openai.ChatCompletionResponseFormatJSONSchema
+				Schema json.RawMessage `json:"schema"` // json.RawMessage implements json.Unmarshaler
+			} `json:"json_schema"`
+		} `json:"response_format"`
+	}
+
+	var tmp tmpRequest
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return openai.ChatCompletionRequest{}, err
+	}
+
+	req = tmp.ChatCompletionRequest
+
+	if format := tmp.ResponseFormat; format != nil {
+		req.ResponseFormat = format.ChatCompletionResponseFormat
+		if jsonSchema := format.JSONSchema; jsonSchema != nil {
+			req.ResponseFormat.JSONSchema = jsonSchema.ChatCompletionResponseFormatJSONSchema
+			if schema := format.JSONSchema.Schema; schema != nil {
+				format.JSONSchema.ChatCompletionResponseFormatJSONSchema.Schema = schema
+			}
+		}
+	}
+
+	return req, nil
 }

--- a/ai/openai_test.go
+++ b/ai/openai_test.go
@@ -1,6 +1,7 @@
 package ai
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/sashabaranov/go-openai"
@@ -73,6 +74,85 @@ func TestConvertToInvokeResponse(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			actual, _ := ConvertToInvokeResponse(tt.args.res, tt.args.tools)
 			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestDecodeChatCompletionRequest(t *testing.T) {
+	type args struct {
+		data string
+	}
+	tests := []struct {
+		name          string
+		args          args
+		wantReq       openai.ChatCompletionRequest
+		wantErrString string
+	}{
+		{
+			name: "response_format=json_schema",
+			args: args{
+				data: `{"model":"gpt-4o","response_format":{"type":"json_schema","json_schema":{"name":"math_reasoning","schema":{"type":"object","properties":{"steps":{"type":"array","items":{"type":"object","properties":{"explanation":{"type":"string"},"output":{"type":"string"}},"required":["explanation","output"],"additionalProperties":false}},"final_answer":{"type":"string"}},"required":["steps","final_answer"],"additionalProperties":false},"strict":true}}}`,
+			},
+			wantReq: openai.ChatCompletionRequest{
+				Model: "gpt-4o",
+				ResponseFormat: &openai.ChatCompletionResponseFormat{
+					Type: openai.ChatCompletionResponseFormatTypeJSONSchema,
+					JSONSchema: &openai.ChatCompletionResponseFormatJSONSchema{
+						Name:   "math_reasoning",
+						Schema: json.RawMessage(`{"type":"object","properties":{"steps":{"type":"array","items":{"type":"object","properties":{"explanation":{"type":"string"},"output":{"type":"string"}},"required":["explanation","output"],"additionalProperties":false}},"final_answer":{"type":"string"}},"required":["steps","final_answer"],"additionalProperties":false}`),
+						Strict: true,
+					},
+				},
+			},
+		},
+		{
+			name: "response_format=json_object",
+			args: args{
+				data: `{"model":"gpt-4o-2024-08-06","response_format":{"type":"json_object"}}`,
+			},
+			wantReq: openai.ChatCompletionRequest{
+				Model: "gpt-4o-2024-08-06",
+				ResponseFormat: &openai.ChatCompletionResponseFormat{
+					Type: openai.ChatCompletionResponseFormatTypeJSONObject,
+				},
+			},
+		},
+		{
+			name: "response_format=text",
+			args: args{
+				data: `{"model":"gpt-4o","response_format":{"type":"text"}}`,
+			},
+			wantReq: openai.ChatCompletionRequest{
+				Model: "gpt-4o",
+				ResponseFormat: &openai.ChatCompletionResponseFormat{
+					Type: openai.ChatCompletionResponseFormatTypeText,
+				},
+			},
+		},
+		{
+			name: "response_format=nil",
+			args: args{
+				data: `{"model":"gpt-4o"}`,
+			},
+			wantReq: openai.ChatCompletionRequest{
+				Model: "gpt-4o",
+			},
+		},
+		{
+			name: "not a json",
+			args: args{
+				data: `model=gpt-4o,response_format=text`,
+			},
+			wantErrString: "invalid character 'm' looking for beginning of value",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotReq, err := DecodeChatCompletionRequest([]byte(tt.args.data))
+			if err != nil {
+				assert.EqualError(t, err, tt.wantErrString)
+			}
+			assert.Equal(t, tt.wantReq, gotReq)
 		})
 	}
 }

--- a/pkg/bridge/ai/provider/githubmodels/provider_test.go
+++ b/pkg/bridge/ai/provider/githubmodels/provider_test.go
@@ -64,8 +64,8 @@ func TestGithubModelsProvider_GetChatCompletions(t *testing.T) {
 
 	_, err := provider.GetChatCompletions(context.TODO(), req, nil)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "401")
-	assert.Contains(t, err.Error(), "Bad credentials")
+	assert.Contains(t, err.Error(), "500")
+	assert.Contains(t, err.Error(), "Specified method is not supported")
 }
 
 func TestGithubModelsProvider_GetChatCompletionsStream(t *testing.T) {
@@ -95,6 +95,6 @@ func TestGithubModelsProvider_GetChatCompletionsStream(t *testing.T) {
 
 	_, err := provider.GetChatCompletionsStream(context.TODO(), req, nil)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "401")
-	assert.Contains(t, err.Error(), "Bad credentials")
+	assert.Contains(t, err.Error(), "500")
+	assert.Contains(t, err.Error(), "Specified method is not supported")
 }


### PR DESCRIPTION
Introduces a new function to decode `ChatCompletionRequest` objects with support for complex `response_format` structures, updates related request handling logic, and modifies some tests to reflect these changes.