### PR TITLE
feat: enhance TypeScript compilation prefer tsgo than tsc

### DIFF
--- a/cli/serverless/nodejs/runtime.go
+++ b/cli/serverless/nodejs/runtime.go
@@ -126,7 +126,7 @@ func (w *NodejsWrapper) Build(env []string) error {
 	} else {
 		tscVersion = v
 	}
-	log.InfoStatusEvent(os.Stdout, "Compiling by %s (%s)", tscCommand, tscVersion)
+	log.InfoStatusEvent(os.Stdout, "Compiling with %s (%s)", tscCommand, tscVersion)
 
 	cmd2 := exec.Command(tscCommand, "-p", "tsconfig.json")
 	cmd2.Dir = w.workDir

--- a/core/client.go
+++ b/core/client.go
@@ -123,7 +123,7 @@ func (c *Client) handleConnectResult(err error, alwaysReconnect bool) (reconnect
 	}
 	if err == nil {
 		c.Logger.Info("connected to zipper")
-		log.InfoStatusEvent(os.Stdout, "[%s] waiting request...", c.name)
+		log.InfoStatusEvent(os.Stdout, "[%s] is waiting for request...", c.name)
 		return false, nil
 	}
 	if e := new(ErrRejected); errors.As(err, &e) {


### PR DESCRIPTION
* Updated the `Build` method to check for the presence of `tsgo` before defaulting to `tsc` for TypeScript compilation. 
* Enhanced the `Run` method to retrieve and log the version of the `bun` runtime, providing clearer feedback about the runtime environment.

### `Build` stage

When `tsgo` is installed:

```sh
$ yomo run

ℹ️  YoMo Serverless LLM Function file: /Users/fanweixiao/_wrk/yomorun/llm-function-calling-examples/node-tool-get-utc-time/src/app.ts
⌛  Creating YoMo Serverless LLM Function instance...
Lockfile is up to date, resolution step is skipped
Already up to date
Done in 215ms using pnpm v10.11.0
ℹ️  Compiling by tsgo (Version 7.0.0-dev.20250529.1)
ℹ️  Starting YoMo Serverless LLM Function instance, connecting to zipper: zipper.vivgrid.com:9000
ℹ️  Serverless LLM Function is running...
ℹ️  Runtime is Bun (Version 1.2.9)
4:47PM INF connected to zipper service=stream-function sfn_id=IPfw8zbTg5RSknoJ-mQwc sfn_name=get-utc-time zipper_addr=zipper.vivgrid.com:9000
ℹ️  [get-utc-time] waiting request...
```

when `tsgo` is NOT installed, fallback to `tsc`:

```sh
yomo run           
ℹ️  YoMo Serverless LLM Function file: /Users/fanweixiao/_wrk/yomorun/llm-function-calling-examples/node-tool-get-utc-time/src/app.ts
⌛  Creating YoMo Serverless LLM Function instance...
Lockfile is up to date, resolution step is skipped
Already up to date
Done in 211ms using pnpm v10.11.0
ℹ️  Compiling by tsc (Version 5.8.3)
ℹ️  Starting YoMo Serverless LLM Function instance, connecting to zipper: zipper.vivgrid.com:9000
ℹ️  Serverless LLM Function is running...
ℹ️  Runtime is Bun (Version 1.2.9)
5:20PM INF connected to zipper service=stream-function sfn_id=u0j1A_nVwSYqbZ2QPNSrQ sfn_name=get-utc-time zipper_addr=zipper.vivgrid.com:9000
ℹ️  [get-utc-time] waiting request...
```

### `Run` Stage

if `bun` is absent, fallback to nodejs:

```sh
~/_wrk/yomorun/yomo/bin/yomo run
ℹ️  YoMo Serverless LLM Function file: /Users/fanweixiao/_wrk/yomorun/llm-function-calling-examples/node-tool-get-utc-time/src/app.ts
⌛  Creating YoMo Serverless LLM Function instance...
Lockfile is up to date, resolution step is skipped
Already up to date
Done in 212ms using pnpm v10.11.0
ℹ️  Compiling by tsc (Version 5.8.3)
ℹ️  Starting YoMo Serverless LLM Function instance, connecting to zipper: zipper.vivgrid.com:9000
ℹ️  Serverless LLM Function is running...
5:23PM INF connected to zipper service=stream-function sfn_id=mxJyAcPvLuiRO6qfhVoWD sfn_name=get-utc-time zipper_addr=zipper.vivgrid.com:9000
ℹ️  [get-utc-time] waiting request...
```
