### PR TITLE
fix(llm-bridge): streaming response miss call result

### DIFF
--- a/pkg/bridge/ai/chat.go
+++ b/pkg/bridge/ai/chat.go
@@ -145,7 +145,9 @@ func multiTurnFunctionCalling(
 				Role:      openai.ChatMessageRoleAssistant,
 				ToolCalls: toolCalls,
 			})
-
+			if req.Stream {
+				_ = w.WriteStreamEvent(toolCalls)
+			}
 			// call functions
 			reqID := id.New(16)
 			callResult, err := caller.Call(callCtx, transID, reqID, toolCalls, tracer)
@@ -156,7 +158,7 @@ func multiTurnFunctionCalling(
 				return err
 			}
 			if req.Stream {
-				_ = w.WriteStreamEvent(toolCalls)
+				_ = w.WriteStreamEvent(callResult)
 			}
 			callSpan.End()
 


### PR DESCRIPTION
This pull request introduces improvements to streaming function call results in the multi-turn function calling flow within `pkg/bridge/ai/chat.go`. The main changes ensure that streaming responses are more accurate and timely by sending the appropriate data at each stage.

Streaming enhancements:

* When streaming is enabled (`req.Stream`), the function now streams the initial `toolCalls` immediately after they are generated, providing faster feedback to the client.
* After the function call is executed, the streaming response now sends the actual `callResult` instead of the original `toolCalls`, ensuring that the client receives the final result of the function call.