### PR TITLE
feat: add Groq and Mistral providers and System Info sfn example

### DIFF
--- a/_examples/sfn-system-info/go.mod
+++ b/_examples/sfn-system-info/go.mod
@@ -1,0 +1,8 @@
+module system-info
+
+go 1.23.0
+
+require (
+	github.com/shirou/gopsutil/v3 v3.24.5
+	github.com/yomorun/yomo v1.18.14
+)

--- a/_examples/sfn-system-info/main.go
+++ b/_examples/sfn-system-info/main.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"runtime"
+	"time"
+
+	"github.com/shirou/gopsutil/v3/cpu"
+	"github.com/shirou/gopsutil/v3/mem"
+	"github.com/yomorun/yomo/serverless"
+)
+
+// Init is an optional function invoked during the initialization phase of the
+// sfn instance.
+func Init() error {
+	return nil
+}
+
+// Description outlines the functionality for the LLM Function Calling feature.
+func Description() string {
+	return `Get the system resource information of the edge node, 
+	including CPU usage, memory usage, and OS information. 
+	This is useful for monitoring the health and load of geo-distributed edge nodes.`
+}
+
+// InputSchema defines the argument structure for LLM Function Calling.
+func InputSchema() any {
+	return &LLMArguments{}
+}
+
+// LLMArguments defines the arguments for the LLM Function Calling.
+type LLMArguments struct {
+	IncludeCPU    bool `json:"include_cpu" jsonschema:"description=Whether to include CPU usage information,default=true"`
+	IncludeMemory bool `json:"include_memory" jsonschema:"description=Whether to include memory usage information,default=true"`
+}
+
+// Handler orchestrates the core processing logic of this function.
+func Handler(ctx serverless.Context) {
+	var p LLMArguments
+	// deserialize the arguments from llm tool_call response
+	ctx.ReadLLMArguments(&p)
+
+	res := "System Information:\n"
+	res += fmt.Sprintf("- OS: %s\n", runtime.GOOS)
+	res += fmt.Sprintf("- Arch: %s\n", runtime.GOARCH)
+
+	if p.IncludeCPU {
+		percent, err := cpu.Percent(time.Second, false)
+		if err == nil && len(percent) > 0 {
+			res += fmt.Sprintf("- CPU Usage: %.2f%%\n", percent[0])
+		}
+	}
+
+	if p.IncludeMemory {
+		v, err := mem.VirtualMemory()
+		if err == nil {
+			res += fmt.Sprintf("- Memory Usage: %.2f%% (Used: %v MB, Total: %v MB)\n", 
+				v.UsedPercent, v.Used/1024/1024, v.Total/1024/1024)
+		}
+	}
+
+	// return the result back to LLM
+	ctx.WriteLLMResult(res)
+
+	slog.Info("system-info", "include_cpu", p.IncludeCPU, "include_memory", p.IncludeMemory, "result", res)
+}

--- a/pkg/bridge/ai/config.go
+++ b/pkg/bridge/ai/config.go
@@ -18,6 +18,8 @@ import (
 	"github.com/yomorun/yomo/pkg/bridge/ai/provider/deepseek"
 	"github.com/yomorun/yomo/pkg/bridge/ai/provider/gemini"
 	"github.com/yomorun/yomo/pkg/bridge/ai/provider/githubmodels"
+	"github.com/yomorun/yomo/pkg/bridge/ai/provider/groq"
+	"github.com/yomorun/yomo/pkg/bridge/ai/provider/mistral"
 	"github.com/yomorun/yomo/pkg/bridge/ai/provider/ollama"
 	"github.com/yomorun/yomo/pkg/bridge/ai/provider/openai"
 	"github.com/yomorun/yomo/pkg/bridge/ai/provider/vertexai"
@@ -211,6 +213,10 @@ func NewProviderFromConfig(name string, provider map[string]string) (providerpkg
 		return gemini.NewProvider(provider["api_key"]), nil
 	case "githubmodels":
 		return githubmodels.NewProvider(provider["api_key"], provider["model"]), nil
+	case "groq":
+		return groq.NewProvider(provider["api_key"], provider["model"]), nil
+	case "mistral":
+		return mistral.NewProvider(provider["api_key"], provider["model"]), nil
 	case "cerebras":
 		return cerebras.NewProvider(provider["api_key"], provider["model"]), nil
 	case "anthropic":

--- a/pkg/bridge/ai/config_test.go
+++ b/pkg/bridge/ai/config_test.go
@@ -120,3 +120,44 @@ func TestParseConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestNewProviderFromConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider map[string]string
+		expected string
+	}{
+		{
+			name: "openai",
+			provider: map[string]string{
+				"api_key": "sk-123456",
+				"model":   "gpt-3.5-turbo",
+			},
+			expected: "openai",
+		},
+		{
+			name: "groq",
+			provider: map[string]string{
+				"api_key": "gsk-123456",
+				"model":   "llama3-8b-8192",
+			},
+			expected: "groq",
+		},
+		{
+			name: "mistral",
+			provider: map[string]string{
+				"api_key": "msk-123456",
+				"model":   "mistral-tiny",
+			},
+			expected: "mistral",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewProviderFromConfig(tt.name, tt.provider)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, got.Name())
+		})
+	}
+}

--- a/pkg/bridge/ai/provider/groq/provider.go
+++ b/pkg/bridge/ai/provider/groq/provider.go
@@ -1,0 +1,65 @@
+// Package groq is the Groq llm provider
+package groq
+
+import (
+	"context"
+
+	"github.com/yomorun/go-openai"
+	"github.com/yomorun/yomo/core/metadata"
+
+	provider "github.com/yomorun/yomo/pkg/bridge/ai/provider"
+)
+
+// based on https://console.groq.com/docs/openai
+const BaseURL = "https://api.groq.com/openai/v1"
+
+// check if implements ai.Provider
+var _ provider.LLMProvider = &Provider{}
+
+// Provider is the provider for groq
+type Provider struct {
+	// APIKey is the API key for groq
+	APIKey string
+	// Model is the model for groq
+	// eg. "llama3-8b-8192", "llama3-70b-8192", "mixtral-8x7b-32768"
+	Model  string
+	client *openai.Client
+}
+
+// NewProvider creates a new groq ai provider
+func NewProvider(apiKey string, model string) *Provider {
+	if model == "" {
+		model = "llama3-8b-8192"
+	}
+	c := openai.DefaultConfig(apiKey)
+	c.BaseURL = BaseURL
+
+	return &Provider{
+		APIKey: apiKey,
+		Model:  model,
+		client: openai.NewClientWithConfig(c),
+	}
+}
+
+// Name returns the name of the provider
+func (p *Provider) Name() string {
+	return "groq"
+}
+
+// GetChatCompletions implements ai.LLMProvider.
+func (p *Provider) GetChatCompletions(ctx context.Context, req openai.ChatCompletionRequest, _ metadata.M) (openai.ChatCompletionResponse, error) {
+	if req.Model == "" {
+		req.Model = p.Model
+	}
+
+	return p.client.CreateChatCompletion(ctx, req)
+}
+
+// GetChatCompletionsStream implements ai.LLMProvider.
+func (p *Provider) GetChatCompletionsStream(ctx context.Context, req openai.ChatCompletionRequest, _ metadata.M) (provider.ResponseRecver, error) {
+	if req.Model == "" {
+		req.Model = p.Model
+	}
+
+	return p.client.CreateChatCompletionStream(ctx, req)
+}

--- a/pkg/bridge/ai/provider/mistral/provider.go
+++ b/pkg/bridge/ai/provider/mistral/provider.go
@@ -1,0 +1,65 @@
+// Package mistral is the Mistral llm provider
+package mistral
+
+import (
+	"context"
+
+	"github.com/yomorun/go-openai"
+	"github.com/yomorun/yomo/core/metadata"
+
+	provider "github.com/yomorun/yomo/pkg/bridge/ai/provider"
+)
+
+// based on https://docs.mistral.ai/api/
+const BaseURL = "https://api.mistral.ai/v1"
+
+// check if implements ai.Provider
+var _ provider.LLMProvider = &Provider{}
+
+// Provider is the provider for mistral
+type Provider struct {
+	// APIKey is the API key for mistral
+	APIKey string
+	// Model is the model for mistral
+	// eg. "mistral-tiny", "mistral-small", "mistral-medium"
+	Model  string
+	client *openai.Client
+}
+
+// NewProvider creates a new mistral ai provider
+func NewProvider(apiKey string, model string) *Provider {
+	if model == "" {
+		model = "mistral-tiny"
+	}
+	c := openai.DefaultConfig(apiKey)
+	c.BaseURL = BaseURL
+
+	return &Provider{
+		APIKey: apiKey,
+		Model:  model,
+		client: openai.NewClientWithConfig(c),
+	}
+}
+
+// Name returns the name of the provider
+func (p *Provider) Name() string {
+	return "mistral"
+}
+
+// GetChatCompletions implements ai.LLMProvider.
+func (p *Provider) GetChatCompletions(ctx context.Context, req openai.ChatCompletionRequest, _ metadata.M) (openai.ChatCompletionResponse, error) {
+	if req.Model == "" {
+		req.Model = p.Model
+	}
+
+	return p.client.CreateChatCompletion(ctx, req)
+}
+
+// GetChatCompletionsStream implements ai.LLMProvider.
+func (p *Provider) GetChatCompletionsStream(ctx context.Context, req openai.ChatCompletionRequest, _ metadata.M) (provider.ResponseRecver, error) {
+	if req.Model == "" {
+		req.Model = p.Model
+	}
+
+	return p.client.CreateChatCompletionStream(ctx, req)
+}


### PR DESCRIPTION
## Description
This PR adds two new LLM providers and a practical Serverless LLM Function (sfn) example to the YoMo ecosystem:

1. **New LLM Providers**:
   - **Groq**: Added support for Groq's ultra-fast Llama3 and Mixtral models via their OpenAI-compatible API. This is highly beneficial for low-latency edge AI scenarios.
   - **Mistral**: Added support for Mistral AI's models.

2. **New Serverless LLM Function (sfn) Example**:
   - **System Information**: A new sfn that provides real-time system resource metrics (CPU, Memory, OS) from edge nodes. This demonstrates how YoMo can be used to monitor geo-distributed edge infrastructure through an AI Agent.
   - Included a dedicated  and  for the example.

## Changes
- : Implementation of Groq provider.
- : Implementation of Mistral provider.
- : Registered the new providers.
- : Added unit tests for provider registration.
- : New sfn example and documentation.

## Verification
- Ran === RUN   TestParseZipperAddr
=== RUN   TestParseZipperAddr/Valid_address
=== RUN   TestParseZipperAddr/Valid_address_of_localhost
[2m3:12PM[0m [91mERR[0m invalid zipper address, return default [2maddr=[0mlocalhost [2mdefault=[0mlocalhost:9000 [2merr=[0m"address localhost: missing port in address"
=== RUN   TestParseZipperAddr/Invalid_address
[2m3:12PM[0m [91mERR[0m invalid zipper address, return default [2maddr=[0minvalid [2mdefault=[0mlocalhost:9000 [2merr=[0m"address invalid: missing port in address"
=== RUN   TestParseZipperAddr/Localhost
=== RUN   TestParseZipperAddr/Unspecified_IP
--- PASS: TestParseZipperAddr (0.00s)
    --- PASS: TestParseZipperAddr/Valid_address (0.00s)
    --- PASS: TestParseZipperAddr/Valid_address_of_localhost (0.00s)
    --- PASS: TestParseZipperAddr/Invalid_address (0.00s)
    --- PASS: TestParseZipperAddr/Localhost (0.00s)
    --- PASS: TestParseZipperAddr/Unspecified_IP (0.00s)
=== RUN   TestParseConfig
=== RUN   TestParseConfig/Config_not_found
=== RUN   TestParseConfig/Config_format_error
=== RUN   TestParseConfig/Valid_config
=== RUN   TestParseConfig/Default_server_address
=== RUN   TestParseConfig/malformaled_config
--- PASS: TestParseConfig (0.00s)
    --- PASS: TestParseConfig/Config_not_found (0.00s)
    --- PASS: TestParseConfig/Config_format_error (0.00s)
    --- PASS: TestParseConfig/Valid_config (0.00s)
    --- PASS: TestParseConfig/Default_server_address (0.00s)
    --- PASS: TestParseConfig/malformaled_config (0.00s)
=== RUN   TestNewProviderFromConfig
=== RUN   TestNewProviderFromConfig/openai
=== RUN   TestNewProviderFromConfig/groq
=== RUN   TestNewProviderFromConfig/mistral
--- PASS: TestNewProviderFromConfig (0.00s)
    --- PASS: TestNewProviderFromConfig/openai (0.00s)
    --- PASS: TestNewProviderFromConfig/groq (0.00s)
    --- PASS: TestNewProviderFromConfig/mistral (0.00s)
=== RUN   TestResponseWriter
--- PASS: TestResponseWriter (0.00s)
=== RUN   TestOpSystemPrompt
=== RUN   TestOpSystemPrompt/disabled
=== RUN   TestOpSystemPrompt/overwrite_with_empty_system_prompt
=== RUN   TestOpSystemPrompt/empty_system_prompt_should_not_overwrite
=== RUN   TestOpSystemPrompt/overwrite_with_not_empty_system_prompt
=== RUN   TestOpSystemPrompt/prefix_with_empty_system_prompt
=== RUN   TestOpSystemPrompt/prefix_with_not_empty_system_prompt
=== RUN   TestOpSystemPrompt/client_preferred_with_client_system_prompt
=== RUN   TestOpSystemPrompt/client_preferred_without_client_system_prompt
=== RUN   TestOpSystemPrompt/client_preferred_with_empty_system_prompt
--- PASS: TestOpSystemPrompt (0.00s)
    --- PASS: TestOpSystemPrompt/disabled (0.00s)
    --- PASS: TestOpSystemPrompt/overwrite_with_empty_system_prompt (0.00s)
    --- PASS: TestOpSystemPrompt/empty_system_prompt_should_not_overwrite (0.00s)
    --- PASS: TestOpSystemPrompt/overwrite_with_not_empty_system_prompt (0.00s)
    --- PASS: TestOpSystemPrompt/prefix_with_empty_system_prompt (0.00s)
    --- PASS: TestOpSystemPrompt/prefix_with_not_empty_system_prompt (0.00s)
    --- PASS: TestOpSystemPrompt/client_preferred_with_client_system_prompt (0.00s)
    --- PASS: TestOpSystemPrompt/client_preferred_without_client_system_prompt (0.00s)
    --- PASS: TestOpSystemPrompt/client_preferred_with_empty_system_prompt (0.00s)
=== RUN   TestServiceInvoke
=== RUN   TestServiceInvoke/invoke_with_tool_call
[mock provider] request: {"model":"","messages":[{"role":"system","content":"this is a system prompt"},{"role":"user","content":"hi"}],"tools":[{"type":"function","function":{"name":"get_current_weather","parameters":null}}]}
[mock provider] request: {"model":"","messages":[{"role":"system","content":"this is a system prompt"},{"role":"user","content":"hi"},{"role":"assistant","tool_calls":[{"id":"call_abc123","type":"function","function":{"name":"get_current_weather","arguments":"{\n\"location\": \"Boston, MA\"\n}"}}]},{"role":"tool","content":"temperature: 31°C","tool_call_id":"call_abc123"}],"tools":[{"type":"function","function":{"name":"get_current_weather","parameters":null}}]}
=== RUN   TestServiceInvoke/invoke_without_tool_call
[mock provider] request: {"model":"","messages":[{"role":"system","content":"this is a system prompt"},{"role":"user","content":"hi"}]}
--- PASS: TestServiceInvoke (0.00s)
    --- PASS: TestServiceInvoke/invoke_with_tool_call (0.00s)
    --- PASS: TestServiceInvoke/invoke_without_tool_call (0.00s)
=== RUN   TestServiceChatCompletion
=== RUN   TestServiceChatCompletion/chat_with_tool_call
[mock provider] request: {"model":"","messages":[{"role":"system","content":"this is a system prompt"},{"role":"user","content":"How is the weather today in Boston, MA?"}],"tools":[{"type":"function","function":{"name":"get_current_weather","parameters":null}}]}
[mock provider] request: {"model":"","messages":[{"role":"system","content":"this is a system prompt"},{"role":"user","content":"How is the weather today in Boston, MA?"},{"role":"assistant","tool_calls":[{"id":"call_abc123","type":"function","function":{"name":"get_current_weather","arguments":"{\n\"location\": \"Boston, MA\"\n}"}}]},{"role":"tool","content":"temperature: 31°C","tool_call_id":"call_abc123"}],"tools":[{"type":"function","function":{"name":"get_current_weather","parameters":null}}]}
=== RUN   TestServiceChatCompletion/chat_without_tool_call
[mock provider] request: {"model":"","messages":[{"role":"system","content":"You are an assistant."},{"role":"user","content":"How are you"}],"tools":[{"type":"function","function":{"name":"get_current_weather","parameters":null}}]}
=== RUN   TestServiceChatCompletion/chat_with_tool_call_in_stream
[mock provider] stream request: {"model":"","messages":[{"role":"system","content":"You are a weather assistant"},{"role":"user","content":"How is the weather today in Boston, MA?"}],"stream":true,"tools":[{"type":"function","function":{"name":"get_current_weather","parameters":null}}]}
[mock provider] stream request: {"model":"","messages":[{"role":"system","content":"You are a weather assistant"},{"role":"user","content":"How is the weather today in Boston, MA?"},{"role":"assistant","tool_calls":[{"index":0,"id":"call_9ctHOJqO3bYrpm2A6S7nHd5k","type":"function","function":{"name":"get_current_weather","arguments":"{\"location\":\"Boston, MA\"}"}}]},{"role":"tool","content":"temperature: 31°C","tool_call_id":"call_9ctHOJqO3bYrpm2A6S7nHd5k"}],"stream":true,"tools":[{"type":"function","function":{"name":"get_current_weather","parameters":null}}]}
=== RUN   TestServiceChatCompletion/chat_without_tool_call_in_stream
[mock provider] stream request: {"model":"","messages":[{"role":"system","content":"You are a weather assistant"},{"role":"user","content":"How is the weather today in Boston, MA?"}],"stream":true,"tools":[{"type":"function","function":{"name":"get_current_weather","parameters":null}}]}
=== RUN   TestServiceChatCompletion/deepseek-v3.2_stream_with_tools
[mock provider] stream request: {"model":"","messages":[{"role":"system","content":"You are a weather assistant"},{"role":"user","content":"how is the weather in tokyo?"}],"stream":true,"tools":[{"type":"function","function":{"name":"market-get-weather","parameters":null}}]}
[mock provider] stream request: {"model":"","messages":[{"role":"system","content":"You are a weather assistant"},{"role":"user","content":"how is the weather in tokyo?"},{"role":"assistant","tool_calls":[{"index":0,"id":"call_a6dea19b4490485bbdad7047","type":"function","function":{"name":"market-get-weather","arguments":"{\"city\": \"Tokyo\", \"latitude\": 35.6762, \"longitude\": 139.6503}"}}]},{"role":"tool","content":"temperature: 31°C","tool_call_id":"call_a6dea19b4490485bbdad7047"}],"stream":true,"tools":[{"type":"function","function":{"name":"market-get-weather","parameters":null}}]}
--- PASS: TestServiceChatCompletion (0.00s)
    --- PASS: TestServiceChatCompletion/chat_with_tool_call (0.00s)
    --- PASS: TestServiceChatCompletion/chat_without_tool_call (0.00s)
    --- PASS: TestServiceChatCompletion/chat_with_tool_call_in_stream (0.00s)
    --- PASS: TestServiceChatCompletion/chat_without_tool_call_in_stream (0.00s)
    --- PASS: TestServiceChatCompletion/deepseek-v3.2_stream_with_tools (0.00s)
PASS
ok  	github.com/yomorun/yomo/pkg/bridge/ai	(cached)
=== RUN   TestTimeoutCallSyncer
--- PASS: TestTimeoutCallSyncer (0.00s)
=== RUN   TestCallSyncer
--- PASS: TestCallSyncer (0.00s)
=== RUN   TestCaller
--- PASS: TestCaller (0.00s)
=== RUN   TestMockCaller
--- PASS: TestMockCaller (0.00s)
PASS
ok  	github.com/yomorun/yomo/pkg/bridge/ai/caller	(cached)
=== RUN   TestMockProviderRequest
[mock provider] request: {"model":"","messages":[{"role":"user","content":"hi, llm bridge"}]}
[mock provider] stream request: {"model":"","messages":[{"role":"user","content":"hi, yomo"}]}
--- PASS: TestMockProviderRequest (0.00s)
=== RUN   TestMockProvider
=== RUN   TestMockProvider/Name()
=== RUN   TestMockProvider/GetChatCompletions()
[mock provider] request: {"model":"gpt-4o-2024-05-13","messages":null}
=== RUN   TestMockProvider/GetChatCompletionsStream()
[mock provider] stream request: {"model":"","messages":null}
--- PASS: TestMockProvider (0.00s)
    --- PASS: TestMockProvider/Name() (0.00s)
    --- PASS: TestMockProvider/GetChatCompletions() (0.00s)
    --- PASS: TestMockProvider/GetChatCompletionsStream() (0.00s)
=== RUN   TestProviders
=== RUN   TestProviders/ListProviders
=== RUN   TestProviders/GetProvider
=== RUN   TestProviders/GetProvider/ok
=== RUN   TestProviders/GetProvider/name_is_empty
=== RUN   TestProviders/GetProvider/not_found
--- PASS: TestProviders (0.00s)
    --- PASS: TestProviders/ListProviders (0.00s)
    --- PASS: TestProviders/GetProvider (0.00s)
        --- PASS: TestProviders/GetProvider/ok (0.00s)
        --- PASS: TestProviders/GetProvider/name_is_empty (0.00s)
        --- PASS: TestProviders/GetProvider/not_found (0.00s)
PASS
ok  	github.com/yomorun/yomo/pkg/bridge/ai/provider	(cached)
?   	github.com/yomorun/yomo/pkg/bridge/ai/provider/anthropic	[no test files]
=== RUN   TestNewProvider
--- PASS: TestNewProvider (0.00s)
=== RUN   TestAzureOpenAIProvider_Name
--- PASS: TestAzureOpenAIProvider_Name (0.00s)
=== RUN   TestAzureOpenAIProvider_GetChatCompletions
    provider_test.go:63: Post "https://yomo.openai.azure.com/openai/deployments/test/chat/completions?api-version=test-version": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
    provider_test.go:66: Post "https://yomo.openai.azure.com/openai/deployments/test/chat/completions?api-version=test-version": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
--- PASS: TestAzureOpenAIProvider_GetChatCompletions (0.00s)
PASS
ok  	github.com/yomorun/yomo/pkg/bridge/ai/provider/azopenai	(cached)
=== RUN   TestAzureAIFoundryProvider_Name
--- PASS: TestAzureAIFoundryProvider_Name (0.00s)
=== RUN   TestAzureOpenAIProvider_GetChatCompletions
--- PASS: TestAzureOpenAIProvider_GetChatCompletions (0.00s)
=== RUN   TestNewProvider
--- PASS: TestNewProvider (0.00s)
=== RUN   TestNewConfigFunction
--- PASS: TestNewConfigFunction (0.00s)
PASS
ok  	github.com/yomorun/yomo/pkg/bridge/ai/provider/azure-ai-foundry	(cached)
=== RUN   TestNewProvider
--- PASS: TestNewProvider (0.00s)
=== RUN   TestCerebrasProvider_Name
--- PASS: TestCerebrasProvider_Name (0.00s)
=== RUN   TestCerebrasProvider_GetChatCompletions
    provider_test.go:48: error, status code: 401, status: 401 Unauthorized, message: %!s(<nil>), body: {"message":"Wrong API Key","type":"invalid_request_error","param":"api_key","code":"wrong_api_key"}
    provider_test.go:52: error, status code: 401, status: 401 Unauthorized, message: %!s(<nil>), body: {"message":"Wrong API Key","type":"invalid_request_error","param":"api_key","code":"wrong_api_key"}
--- PASS: TestCerebrasProvider_GetChatCompletions (1.79s)
PASS
ok  	github.com/yomorun/yomo/pkg/bridge/ai/provider/cerebras	(cached)
=== RUN   TestNewProvider
[2m3:12PM[0m [91mERR[0m parameters are required [2mcfEndpoint=[0m"" [2mapiKey=[0m"" [2mresource=[0m"" [2mdeploymentID=[0m""
--- PASS: TestNewProvider (0.00s)
=== RUN   TestName
--- PASS: TestName (0.00s)
=== RUN   TestCloudflareAzureProvider_GetChatCompletions
    provider_test.go:65: Post "https://facker.gateway.ai.cloudflare.com/v1/111111111111111111/ai-cc-test/azure-openai/test/test/chat/completions?api-version=test-version": EOF
    provider_test.go:68: Post "https://facker.gateway.ai.cloudflare.com/v1/111111111111111111/ai-cc-test/azure-openai/test/test/chat/completions?api-version=test-version": EOF
--- PASS: TestCloudflareAzureProvider_GetChatCompletions (3.54s)
PASS
ok  	github.com/yomorun/yomo/pkg/bridge/ai/provider/cfazure	(cached)
=== RUN   TestCloudflareOpenAIProvider_Name
--- PASS: TestCloudflareOpenAIProvider_Name (0.00s)
=== RUN   TestNewProvider
=== RUN   TestNewProvider/with_parameters
=== RUN   TestNewProvider/with_environment_variables
--- PASS: TestNewProvider (0.00s)
    --- PASS: TestNewProvider/with_parameters (0.00s)
    --- PASS: TestNewProvider/with_environment_variables (0.00s)
=== RUN   TestCloudflareOpenAIProvider_GetChatCompletions
    provider_test.go:70: Post "https://faker.gateway.ai.cloudflare.com/v1/111111111111111111/ai-cc-test/openai/chat/completions": EOF
    provider_test.go:73: Post "https://faker.gateway.ai.cloudflare.com/v1/111111111111111111/ai-cc-test/openai/chat/completions": EOF
--- PASS: TestCloudflareOpenAIProvider_GetChatCompletions (3.44s)
PASS
ok  	github.com/yomorun/yomo/pkg/bridge/ai/provider/cfopenai	(cached)
=== RUN   TestDeepSeekProvider_Name
--- PASS: TestDeepSeekProvider_Name (0.00s)
=== RUN   TestDeepSeekProvider_GetChatCompletions
    provider_test.go:37: error, status code: 401, status: 401 Unauthorized, message: invalid character 'A' looking for beginning of value, body: Authentication Fails (governor)
    provider_test.go:41: error, status code: 401, status: 401 Unauthorized, message: invalid character 'A' looking for beginning of value, body: Authentication Fails (governor)
--- PASS: TestDeepSeekProvider_GetChatCompletions (0.37s)
=== RUN   TestDeepSeekProvider_GetChatCompletionsWithoutModel
    provider_test.go:62: error, status code: 401, status: 401 Unauthorized, message: invalid character 'A' looking for beginning of value, body: Authentication Fails (governor)
    provider_test.go:66: error, status code: 401, status: 401 Unauthorized, message: invalid character 'A' looking for beginning of value, body: Authentication Fails (governor)
--- PASS: TestDeepSeekProvider_GetChatCompletionsWithoutModel (0.05s)
PASS
ok  	github.com/yomorun/yomo/pkg/bridge/ai/provider/deepseek	(cached)
?   	github.com/yomorun/yomo/pkg/bridge/ai/provider/gemini	[no test files]
=== RUN   TestGithubModelsProvider_Name
--- PASS: TestGithubModelsProvider_Name (0.00s)
=== RUN   TestNewProvider
=== RUN   TestNewProvider/with_parameters
=== RUN   TestNewProvider/with_environment_variables
--- PASS: TestNewProvider (0.00s)
    --- PASS: TestNewProvider/with_parameters (0.00s)
    --- PASS: TestNewProvider/with_environment_variables (0.00s)
=== RUN   TestGithubModelsProvider_GetChatCompletions
--- PASS: TestGithubModelsProvider_GetChatCompletions (2.53s)
=== RUN   TestGithubModelsProvider_GetChatCompletionsStream
--- PASS: TestGithubModelsProvider_GetChatCompletionsStream (0.43s)
PASS
ok  	github.com/yomorun/yomo/pkg/bridge/ai/provider/githubmodels	(cached)
?   	github.com/yomorun/yomo/pkg/bridge/ai/provider/groq	[no test files]
?   	github.com/yomorun/yomo/pkg/bridge/ai/provider/mistral	[no test files]
?   	github.com/yomorun/yomo/pkg/bridge/ai/provider/ollama	[no test files]
=== RUN   TestNewProvider
--- PASS: TestNewProvider (0.00s)
=== RUN   TestOpenAIProvider_Name
--- PASS: TestOpenAIProvider_Name (0.00s)
=== RUN   TestCloudflareOpenAIProvider_GetChatCompletions
    provider_test.go:60: Post "https://api.openai.com/v1/chat/completions": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
    provider_test.go:63: Post "https://api.openai.com/v1/chat/completions": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
--- PASS: TestCloudflareOpenAIProvider_GetChatCompletions (0.00s)
PASS
ok  	github.com/yomorun/yomo/pkg/bridge/ai/provider/openai	(cached)
?   	github.com/yomorun/yomo/pkg/bridge/ai/provider/vertexai	[no test files]
=== RUN   TestVLlmProvider_Name
--- PASS: TestVLlmProvider_Name (0.00s)
=== RUN   TestVLlmProvider_GetChatCompletions
    provider_test.go:37: Post "http://127.0.0.1:8000/chat/completions": dial tcp 127.0.0.1:8000: connect: connection refused
    provider_test.go:41: Post "http://127.0.0.1:8000/chat/completions": dial tcp 127.0.0.1:8000: connect: connection refused
--- PASS: TestVLlmProvider_GetChatCompletions (0.00s)
=== RUN   TestVLlmProvider_GetChatCompletionsWithoutModel
    provider_test.go:62: Post "http://127.0.0.1:8000/chat/completions": dial tcp 127.0.0.1:8000: connect: connection refused
    provider_test.go:66: Post "http://127.0.0.1:8000/chat/completions": dial tcp 127.0.0.1:8000: connect: connection refused
--- PASS: TestVLlmProvider_GetChatCompletionsWithoutModel (0.00s)
PASS
ok  	github.com/yomorun/yomo/pkg/bridge/ai/provider/vllm	(cached)
=== RUN   TestXAIProvider_Name
--- PASS: TestXAIProvider_Name (0.00s)
=== RUN   TestXAIProvider_GetChatCompletions
    provider_test.go:41: Post "https://api.x.ai/v1/chat/completions": context deadline exceeded
    provider_test.go:45: Post "https://api.x.ai/v1/chat/completions": context deadline exceeded
    provider_test.go:53: Post "https://api.x.ai/v1/chat/completions": context deadline exceeded
    provider_test.go:57: Post "https://api.x.ai/v1/chat/completions": context deadline exceeded
--- PASS: TestXAIProvider_GetChatCompletions (1.00s)
PASS
ok  	github.com/yomorun/yomo/pkg/bridge/ai/provider/xai	(cached)
=== RUN   TestRegister
--- PASS: TestRegister (0.00s)
PASS
ok  	github.com/yomorun/yomo/pkg/bridge/ai/register	(cached) and all tests passed (including the new provider tests).
- Verified the build process for the new sfn example.