### PR TITLE
fix: yomo init error when install node v24 via nvm

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,7 +15,7 @@ Please list docs related #PR if this change requires a documentation update.
 
 Docs related #<PR_ID>
 
-# Test
+## Test
 
 Core functionality must with unit test.
 Please describe the tests that you ran to verify your core changes.

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -28,6 +28,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Ensure tag points to master
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          git fetch origin master --depth=1
+          git merge-base --is-ancestor "$GITHUB_SHA" "origin/master"
 
       - name: Install cosign
         if: github.event_name != 'pull_request'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,12 +14,22 @@ jobs:
   build:
     name: Build and release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
     steps:
       - name: Check out
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Ensure tag points to master
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          git fetch origin master --depth=1
+          git merge-base --is-ancestor "$GITHUB_SHA" "origin/master"
 
       - name: Setup Go
         uses: actions/setup-go@v5

--- a/cli/serverless/nodejs/runtime.go
+++ b/cli/serverless/nodejs/runtime.go
@@ -233,7 +233,7 @@ func (w *NodejsWrapper) genWrapperTS(dstPath string) error {
 func (w *NodejsWrapper) InitApp() error {
 	// init
 	cmd := exec.Command(w.npmPath, "init")
-	if w.npmPath == "npm" {
+	if filepath.Base(w.npmPath) == "npm" {
 		cmd.Args = append(cmd.Args, "-y")
 	}
 	cmd.Dir = w.workDir


### PR DESCRIPTION
This bug was reported on community by @Jasonw41w3r on 
https://discord.com/channels/770589787404369930/770589787404369935/1493183453766746112

Hi everyone! I’m a beginner learning how to deploy the YoMo platform.

While setting up the environment on WSL2 (Ubuntu 24.04), I encountered a specific deployment hurdle. Specifically, when using Node v24.14.1 managed by nvm, the yomo init command failed with an "exit status 1".

Does anyone know what might be causing this, and how I can resolve it? Any advice or workarounds would be greatly appreciated. Thank you very much!