### PR TITLE
fix: normalize upstream error mapping for content filters

### DIFF
--- a/src/llm_api.rs
+++ b/src/llm_api.rs
@@ -288,11 +288,15 @@ where
             let first_event = match first_item {
                 Ok(event) => event,
                 Err(err) => {
-                    error!(
-                        "http.request.end; status_code=500 model_id={} error={} trace_id={} metadata={:?}",
-                        model_id, err, trace_id, metadata
-                    );
                     let status = provider_error_status(&err);
+                    error!(
+                        "http.request.end; status_code={} model_id={} error={} trace_id={} metadata={:?}",
+                        status.as_u16(),
+                        model_id,
+                        err,
+                        trace_id,
+                        metadata
+                    );
                     let status_message = trace_status_message_for_provider_error(&err, status);
                     let response = map_chat_error(err);
                     set_http_span_status(&root_span, status, Some(status_message.as_str()));
@@ -312,11 +316,15 @@ where
                 .expect("build response"))
         }
         Err(err) => {
-            error!(
-                "http.request.end; status_code=500 model_id={} error={} trace_id={} metadata={:?}",
-                model_id, err, trace_id, metadata
-            );
             let status = provider_error_status(&err);
+            error!(
+                "http.request.end; status_code={} model_id={} error={} trace_id={} metadata={:?}",
+                status.as_u16(),
+                model_id,
+                err,
+                trace_id,
+                metadata
+            );
             let status_message = trace_status_message_for_provider_error(&err, status);
             let response = map_chat_error(err);
             set_http_span_status(&root_span, status, Some(status_message.as_str()));

--- a/src/llm_provider/openai.rs
+++ b/src/llm_provider/openai.rs
@@ -17,6 +17,9 @@ pub struct OpenAIProvider {
     model_id: Option<String>,
 }
 
+const CONTENT_FILTER_MESSAGE: &str =
+    "The request was rejected by the safety policy. Please revise your input and try again.";
+
 impl OpenAIProvider {
     pub fn new(
         client: crate::llm_provider::openai_compatible::client::Client,
@@ -94,8 +97,7 @@ fn map_openai_error(err: ClientError, model: &str) -> ProviderError {
     match err {
         ClientError::Api(ApiError::OpenAI { status, mut error }) if status.as_u16() == 400 => {
             if error.code.as_deref() == Some("content_filter") {
-                error.message = "The response was filtered due to the prompt triggering content management policy. Please modify your prompt and retry"
-                    .to_string();
+                error.message = CONTENT_FILTER_MESSAGE.to_string();
             }
             if error.code.as_deref() == Some("OperationNotSupported") {
                 error.message = format!(
@@ -329,10 +331,7 @@ mod tests {
         let ProviderError::Public { error, .. } = mapped else {
             panic!("expected public error");
         };
-        assert_eq!(
-            error.message,
-            "The response was filtered due to the prompt triggering content management policy. Please modify your prompt and retry"
-        );
+        assert_eq!(error.message, CONTENT_FILTER_MESSAGE);
     }
 
     #[test]

--- a/src/llm_provider/openai_compatible/client.rs
+++ b/src/llm_provider/openai_compatible/client.rs
@@ -6,6 +6,7 @@ use futures_core::Stream;
 use futures_util::StreamExt;
 use log::{Level, debug, log_enabled};
 use reqwest::StatusCode;
+use serde::Deserialize;
 use serde_json::Value;
 use tokio::time::timeout;
 
@@ -54,6 +55,39 @@ pub enum ApiError {
         status: StatusCode,
         body: String,
     },
+}
+
+#[derive(Debug, Deserialize)]
+struct UpstreamErrorResponse {
+    error: UpstreamErrorDetail,
+}
+
+/// Upstream error payload compatible with both OpenAI and Azure OpenAI.
+///
+/// This structure is intentionally permissive and then normalized into `ErrorDetail`.
+#[derive(Debug, Deserialize)]
+struct UpstreamErrorDetail {
+    /// Human-readable upstream error message (present in both OpenAI and Azure OpenAI).
+    message: String,
+    /// Error category. Azure OpenAI can return `null`, so this field stays optional.
+    #[serde(rename = "type")]
+    r#type: Option<String>,
+    /// Provider error code, such as `content_filter`.
+    #[serde(default)]
+    code: Option<String>,
+    /// Related request parameter name, such as `prompt`.
+    #[serde(default)]
+    param: Option<String>,
+    /// Azure-specific field nested inside `error`.
+    ///
+    /// We do not use this value for status mapping because the HTTP status line is the source
+    /// of truth.
+    #[serde(default, rename = "status")]
+    _status: Option<u16>,
+    /// Azure-specific nested error payload (for example `ResponsibleAIPolicyViolation` and
+    /// `content_filter_result`).
+    #[serde(default, rename = "innererror")]
+    _innererror: Option<Value>,
 }
 
 impl std::fmt::Display for ApiError {
@@ -274,9 +308,45 @@ impl Client {
             });
         }
 
+        if let Ok(parsed) = serde_json::from_slice::<UpstreamErrorResponse>(body) {
+            return ClientError::Api(ApiError::OpenAI {
+                status,
+                error: normalize_upstream_error(parsed.error, status),
+            });
+        }
+
         let text = String::from_utf8_lossy(body).to_string();
         ClientError::Api(ApiError::Unknown { status, body: text })
     }
+}
+
+fn normalize_upstream_error(detail: UpstreamErrorDetail, status: StatusCode) -> ErrorDetail {
+    let error_type = detail
+        .r#type
+        .and_then(|value| {
+            let trimmed = value.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            }
+        })
+        .unwrap_or_else(|| default_error_type_for_status(status).to_string());
+
+    ErrorDetail {
+        message: detail.message,
+        r#type: error_type,
+        code: detail.code,
+        param: detail.param,
+    }
+}
+
+fn default_error_type_for_status(status: StatusCode) -> &'static str {
+    if status == StatusCode::BAD_REQUEST {
+        return "invalid_request_error";
+    }
+
+    "internal_error"
 }
 
 fn debug_body(bytes: &[u8]) -> String {
@@ -368,5 +438,53 @@ mod tests {
         clear_agent_context(&mut request);
 
         assert!(request.agent_context.is_none());
+    }
+
+    #[test]
+    fn parse_error_accepts_upstream_null_type_for_bad_request() {
+        let client = Client::new(Config::new("test-key")).expect("build client");
+        let body = br#"{
+            "error": {
+                "message": "filtered",
+                "type": null,
+                "param": "prompt",
+                "code": "content_filter",
+                "status": 400,
+                "innererror": {
+                    "code": "ResponsibleAIPolicyViolation"
+                }
+            }
+        }"#;
+
+        let parsed = client.parse_error(StatusCode::BAD_REQUEST, body);
+
+        let ClientError::Api(ApiError::OpenAI { status, error }) = parsed else {
+            panic!("expected openai api error");
+        };
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(error.message, "filtered");
+        assert_eq!(error.r#type, "invalid_request_error");
+        assert_eq!(error.code.as_deref(), Some("content_filter"));
+        assert_eq!(error.param.as_deref(), Some("prompt"));
+    }
+
+    #[test]
+    fn parse_error_defaults_null_type_to_internal_error_for_non_bad_request() {
+        let client = Client::new(Config::new("test-key")).expect("build client");
+        let body = br#"{
+            "error": {
+                "message": "upstream failed",
+                "type": null,
+                "code": "server_error"
+            }
+        }"#;
+
+        let parsed = client.parse_error(StatusCode::INTERNAL_SERVER_ERROR, body);
+
+        let ClientError::Api(ApiError::OpenAI { status, error }) = parsed else {
+            panic!("expected openai api error");
+        };
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(error.r#type, "internal_error");
     }
 }

--- a/src/llm_provider/openai_compatible/client.rs
+++ b/src/llm_provider/openai_compatible/client.rs
@@ -11,7 +11,7 @@ use serde_json::Value;
 use tokio::time::timeout;
 
 use crate::openai_types::{
-    ChatCompletionChunk, ChatCompletionRequest, ChatCompletionResponse, ErrorDetail, ErrorResponse,
+    ChatCompletionChunk, ChatCompletionRequest, ChatCompletionResponse, ErrorDetail,
 };
 use crate::utils::{MAX_LOG_BODY_BYTES, truncate_for_log};
 
@@ -299,13 +299,6 @@ impl Client {
             if let Some(custom) = (parser)(body) {
                 return ClientError::Api(ApiError::Custom(custom));
             }
-        }
-
-        if let Ok(parsed) = serde_json::from_slice::<ErrorResponse>(body) {
-            return ClientError::Api(ApiError::OpenAI {
-                status,
-                error: parsed.error,
-            });
         }
 
         if let Ok(parsed) = serde_json::from_slice::<UpstreamErrorResponse>(body) {

--- a/src/llm_provider/openai_compatible/mod.rs
+++ b/src/llm_provider/openai_compatible/mod.rs
@@ -16,6 +16,9 @@ pub mod client;
 
 pub mod mapper;
 
+const CONTENT_FILTER_MESSAGE: &str =
+    "The request was rejected by the safety policy. Please revise your input and try again.";
+
 #[derive(Clone)]
 pub struct OpenAICompatibleProvider {
     client: client::Client,
@@ -89,7 +92,10 @@ impl<M> Provider<M> for OpenAICompatibleProvider {
 
 fn map_openai_error(err: ClientError) -> ProviderError {
     match err {
-        ClientError::Api(ApiError::OpenAI { status, error }) if status.as_u16() == 400 => {
+        ClientError::Api(ApiError::OpenAI { status, mut error }) if status.as_u16() == 400 => {
+            if error.code.as_deref() == Some("content_filter") {
+                error.message = CONTENT_FILTER_MESSAGE.to_string();
+            }
             ProviderError::Public {
                 status: StatusCode::BAD_REQUEST,
                 error,
@@ -123,4 +129,54 @@ pub fn build_openai_compatible_provider(
 
 fn validate_request(request: &ChatCompletionRequest) -> Result<(), ProviderError> {
     validate_openai_request(request).map_err(ProviderError::internal)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CONTENT_FILTER_MESSAGE;
+    use super::map_openai_error;
+    use crate::llm_provider::ProviderError;
+    use crate::llm_provider::openai_compatible::client::{ApiError, ClientError};
+    use crate::openai_types::ErrorDetail;
+
+    #[test]
+    fn map_openai_error_rewrites_content_filter_message() {
+        let err = ClientError::Api(ApiError::OpenAI {
+            status: reqwest::StatusCode::BAD_REQUEST,
+            error: ErrorDetail {
+                message: "upstream message".to_string(),
+                r#type: "invalid_request_error".to_string(),
+                code: Some("content_filter".to_string()),
+                param: None,
+            },
+        });
+
+        let mapped = map_openai_error(err);
+
+        let ProviderError::Public { status, error } = mapped else {
+            panic!("expected public error");
+        };
+        assert_eq!(status, axum::http::StatusCode::BAD_REQUEST);
+        assert_eq!(error.message, CONTENT_FILTER_MESSAGE);
+    }
+
+    #[test]
+    fn map_openai_error_keeps_non_filter_bad_request_message() {
+        let err = ClientError::Api(ApiError::OpenAI {
+            status: reqwest::StatusCode::BAD_REQUEST,
+            error: ErrorDetail {
+                message: "original".to_string(),
+                r#type: "invalid_request_error".to_string(),
+                code: Some("invalid_parameter".to_string()),
+                param: None,
+            },
+        });
+
+        let mapped = map_openai_error(err);
+
+        let ProviderError::Public { error, .. } = mapped else {
+            panic!("expected public error");
+        };
+        assert_eq!(error.message, "original");
+    }
 }

--- a/src/openai_http_mapping.rs
+++ b/src/openai_http_mapping.rs
@@ -1581,7 +1581,7 @@ pub fn map_chat_error(err: ProviderError) -> Response {
         }
         ProviderError::Internal { .. } => openai_error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
-            "internal error",
+            "Internal Server Error",
             Some("internal_error"),
         ),
     }


### PR DESCRIPTION
When the upstream returns an Azure OpenAI-style error, `error.type` may be `null`. Our current parsing path assumes a strict OpenAI error schema, so these responses can be downgraded to internal errors, causing requests that should return `400` to appear as `500`. In addition, the logs currently include a misleading `status_code=500` entry.