### PR TITLE
fix: support reasoning alias in openai-compatible parsing

### DIFF
--- a/src/openai_types.rs
+++ b/src/openai_types.rs
@@ -167,6 +167,7 @@ pub struct Message {
     pub role: Role,
     #[serde(default, deserialize_with = "null_to_default")]
     pub content: Content,
+    #[serde(alias = "reasoning")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning_content: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -185,6 +186,7 @@ impl<'de> Deserialize<'de> for Message {
             role: Role,
             #[serde(default, deserialize_with = "null_to_default")]
             content: Content,
+            #[serde(alias = "reasoning")]
             #[serde(skip_serializing_if = "Option::is_none")]
             reasoning_content: Option<String>,
             #[serde(skip_serializing_if = "Option::is_none")]
@@ -530,6 +532,13 @@ mod tests {
     fn chat_completion_message_deserializes_reasoning_content() {
         let message = r#"{"role":"assistant","content":"ok","reasoning_content":"think"}"#;
         let parsed: ChatCompletionMessage = serde_json::from_str(message).expect("parse message");
+        assert_eq!(parsed.reasoning_content.as_deref(), Some("think"));
+    }
+
+    #[test]
+    fn message_deserializes_reasoning_alias() {
+        let message = r#"{"role":"assistant","content":"ok","reasoning":"think"}"#;
+        let parsed: Message = serde_json::from_str(message).expect("parse message");
         assert_eq!(parsed.reasoning_content.as_deref(), Some("think"));
     }
 

--- a/src/openai_types.rs
+++ b/src/openai_types.rs
@@ -355,6 +355,7 @@ pub struct ChatCompletionChoice {
 pub struct ChatCompletionMessage {
     pub role: Role,
     pub content: Option<Content>,
+    #[serde(alias = "reasoning")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning_content: Option<String>,
     #[serde(default, deserialize_with = "null_to_default")]
@@ -416,6 +417,7 @@ pub struct ChatCompletionChunkDelta {
     pub role: Option<Role>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<String>,
+    #[serde(alias = "reasoning")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning_content: Option<String>,
     pub refusal: Option<String>,
@@ -529,6 +531,38 @@ mod tests {
         let message = r#"{"role":"assistant","content":"ok","reasoning_content":"think"}"#;
         let parsed: ChatCompletionMessage = serde_json::from_str(message).expect("parse message");
         assert_eq!(parsed.reasoning_content.as_deref(), Some("think"));
+    }
+
+    #[test]
+    fn chat_completion_message_deserializes_reasoning_alias() {
+        let message = r#"{"role":"assistant","content":"ok","reasoning":"think"}"#;
+        let parsed: ChatCompletionMessage = serde_json::from_str(message).expect("parse message");
+        assert_eq!(parsed.reasoning_content.as_deref(), Some("think"));
+    }
+
+    #[test]
+    fn chat_completion_chunk_deserializes_reasoning_alias() {
+        let chunk = r#"{
+            "id":"chunk-1",
+            "created":1,
+            "model":"DeepSeek-V4-Flash",
+            "object":"chat.completion.chunk",
+            "system_fingerprint":null,
+            "obfuscation":null,
+            "choices":[{
+                "delta":{"reasoning":"step"},
+                "finish_reason":null,
+                "index":0,
+                "logprobs":null
+            }],
+            "usage":null
+        }"#;
+
+        let parsed: ChatCompletionChunk = serde_json::from_str(chunk).expect("parse chunk");
+        assert_eq!(
+            parsed.choices[0].delta.reasoning_content.as_deref(),
+            Some("step")
+        );
     }
 
     #[test]


### PR DESCRIPTION
Description:
## Summary
- Add OpenAI-compatible deserialization support for upstream `reasoning` as an alias of `reasoning_content` in non-stream responses.
- Add the same alias support for stream deltas (`chat.completion.chunk`) so `stream=true` responses preserve thinking content.
- Keep output schema unchanged by continuing to expose `reasoning_content` to downstream clients.
## Why
Some upstream providers (e.g. DeepSeek via vLLM) return reasoning text in `message.reasoning` / `delta.reasoning` instead of `reasoning_content`.  
Without alias handling, reasoning tokens are silently dropped even though normal content is parsed successfully.
## Changes
- `ChatCompletionMessage.reasoning_content` now accepts `reasoning` as a serde alias.
- `ChatCompletionChunkDelta.reasoning_content` now accepts `reasoning` as a serde alias.
- Added unit tests for both non-stream and stream alias deserialization paths.
## Validation
- `cargo fmt`
- `cargo check`
- `cargo test openai_types`