### PR TITLE
fix: make node serverless template path resolution ESM-safe

### DIFF
--- a/serverless/node/main.ts
+++ b/serverless/node/main.ts
@@ -76,7 +76,7 @@ function generateParametersSchema(appTsPath: string): unknown {
   try {
     const generator = tsj.createGenerator({
       path: appTsPath,
-      tsconfig: join(__dirname, "..", "tsconfig.json"),
+      tsconfig: join(process.cwd(), "tsconfig.json"),
       type: "Argument",
       topRef: false,
       expose: "none",
@@ -190,7 +190,7 @@ async function handleConnection(socket: Socket, toolModule: ToolModule): Promise
 async function main(): Promise<void> {
   const toolModule = (await import("./src/app.js")) as ToolModule
   const description = typeof toolModule.description === "string" ? toolModule.description : ""
-  const appTsPath = join(__dirname, "..", "src", "app.ts")
+  const appTsPath = join(process.cwd(), "src", "app.ts")
   const parameters = generateParametersSchema(appTsPath)
 
   const schema = {


### PR DESCRIPTION
## Summary
- Fix Node serverless template startup failure when tool projects use \"type\": \"module\".
- Replace `__dirname`-based path resolution with `process.cwd()` for `tsconfig.json` and `src/app.ts`.
- Keep existing runtime behavior while making startup compatible with both ESM and CJS.