### PR TITLE
fix: emit stream usage after tool calls

### DIFF
--- a/src/agent_loop.rs
+++ b/src/agent_loop.rs
@@ -506,24 +506,26 @@ where
                     _ => {}
                 }
 
+                if let UnifiedEvent::Usage { usage: chunk_usage } = event {
+                    round_state.raw_usage = Some(chunk_usage.clone());
+                    let processed_usage = chunk_usage.into_payload("/chat/completions");
+                    round_state.openai_usage_payload = Some(processed_usage.clone());
+                    let mut usage_with_history = loop_state.round_usages.clone();
+                    usage_with_history.push(processed_usage);
+                    let usage_with_offset =
+                        aggregate_usages_to_value("/chat/completions", &usage_with_history);
+                    yield UnifiedEvent::Usage {
+                        usage: EndpointUsage::from_endpoint_payload(
+                            "/chat/completions",
+                            usage_with_offset,
+                        )
+                        .expect("agent_loop expected chat/completions usage payload"),
+                    };
+                    continue;
+                }
+
                 if !round_state.saw_tool_call {
                     match event {
-                        UnifiedEvent::Usage { usage: chunk_usage } => {
-                            round_state.raw_usage = Some(chunk_usage.clone());
-                            let processed_usage = chunk_usage.into_payload("/chat/completions");
-                            round_state.openai_usage_payload = Some(processed_usage.clone());
-                            let mut usage_with_history = loop_state.round_usages.clone();
-                            usage_with_history.push(processed_usage);
-                            let usage_with_offset =
-                                aggregate_usages_to_value("/chat/completions", &usage_with_history);
-                            yield UnifiedEvent::Usage {
-                                usage: EndpointUsage::from_endpoint_payload(
-                                    "/chat/completions",
-                                    usage_with_offset,
-                                )
-                                .expect("agent_loop expected chat/completions usage payload"),
-                            };
-                        }
                         UnifiedEvent::Completed { finish_reason } => {
                             yield UnifiedEvent::Completed {
                                 finish_reason,
@@ -1452,6 +1454,73 @@ mod tests {
             event.expect("stream event should be ok");
         }
 
+        let calls = usage_handler.captured();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(
+            calls[0].clone().into_payload("/chat/completions"),
+            serde_json::json!({
+                "prompt_tokens": 22,
+                "completion_tokens": 4,
+                "total_tokens": 26
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn run_agent_loop_stream_emits_usage_after_tool_call() {
+        let usage_handler = RecordingUsageHandler::default();
+        let provider = StaticStreamProvider {
+            events: Arc::new(vec![
+                UnifiedEvent::MessageStart {
+                    id: "req-1".to_string(),
+                    role: "assistant".to_string(),
+                },
+                UnifiedEvent::ToolCallDone {
+                    id: "tool-1".to_string(),
+                    name: "client_tool".to_string(),
+                    arguments: "{}".to_string(),
+                },
+                UnifiedEvent::Usage {
+                    usage: usage(22, 4, 26),
+                },
+                UnifiedEvent::Completed {
+                    finish_reason: Some("tool_calls".to_string()),
+                },
+            ]),
+        };
+        let config = AgentLoopConfig {
+            max_calls: 1,
+            usage_handler: Arc::new(usage_handler.clone()),
+            ..AgentLoopConfig::default()
+        };
+
+        let result = run_agent_loop::<(), ()>(
+            Arc::new(provider),
+            stream_request(),
+            HashMap::new(),
+            Arc::new(NoopToolInvoker),
+            (),
+            "trace-1".to_string(),
+            None,
+            config,
+        )
+        .await
+        .expect("stream run should succeed");
+
+        let AgentLoopResult::Stream { mut events } = result else {
+            panic!("expected stream result");
+        };
+        let mut output_usages = Vec::new();
+        while let Some(event) = events.next().await {
+            if let UnifiedEvent::Usage { usage } = event.expect("stream event should be ok") {
+                output_usages.push(usage.into_payload("/chat/completions"));
+            }
+        }
+
+        assert_eq!(output_usages.len(), 1);
+        assert_eq!(output_usages[0]["prompt_tokens"], 22);
+        assert_eq!(output_usages[0]["completion_tokens"], 4);
+        assert_eq!(output_usages[0]["total_tokens"], 26);
         let calls = usage_handler.captured();
         assert_eq!(calls.len(), 1);
         assert_eq!(

--- a/src/agent_loop.rs
+++ b/src/agent_loop.rs
@@ -494,11 +494,6 @@ where
                             };
                         }
                     }
-                    UnifiedEvent::Usage { usage: chunk_usage } => {
-                        round_state.raw_usage = Some(chunk_usage.clone());
-                        round_state.openai_usage_payload =
-                            Some(chunk_usage.clone().into_payload("/chat/completions"));
-                    }
                     UnifiedEvent::Completed { finish_reason: reason } => {
                         round_state.finish_reason = reason.clone();
                         loop_state.last_finish_reason = reason.clone();


### PR DESCRIPTION
## Summary
- Fix a streaming usage propagation bug in agent loop tool-call flows.

## Root Cause
- When `saw_tool_call` was true, stream usage events were suppressed from downstream output.
- This caused nested/upstream callers (for example BYOC calling vivgrid via `type=vivgrid`) to miss usage events, so their `on_usage` handlers were not triggered, even though local usage handling still ran.

## Fix
- Decouple usage emission from the `saw_tool_call` branch.
- Always emit stream `Usage` events downstream when they are received.
- Keep the existing safeguard of one `on_usage` invocation per round to avoid duplicate accounting.
- Add a regression test for `tool_call + usage` streaming to ensure usage is propagated while handler invocation remains single-per-round.