### PR TITLE
fix: avoid streaming non-2xx model API responses

### DIFF
--- a/src/model_api_provider/provider.rs
+++ b/src/model_api_provider/provider.rs
@@ -153,9 +153,9 @@ pub async fn proxy_request(
 
     let status = response.status();
     let mut resp_headers = filter_response_headers(response.headers());
-    let is_stream = req.is_stream;
+    let is_stream_response = should_stream_response(req.is_stream, status);
 
-    if is_stream {
+    if is_stream_response {
         resp_headers.remove(axum::http::header::CONTENT_LENGTH);
         let stream = response.bytes_stream().map(|chunk| match chunk {
             Ok(bytes) => Ok(bytes),
@@ -176,6 +176,10 @@ pub async fn proxy_request(
             body: ProviderBody::Full(bytes),
         })
     }
+}
+
+fn should_stream_response(is_stream_request: bool, status: StatusCode) -> bool {
+    is_stream_request && status.is_success()
 }
 
 pub(crate) fn rewrite_json_model(body: &Bytes, model: &str) -> Result<Bytes, anyhow::Error> {
@@ -334,4 +338,29 @@ fn is_hop_header(header: &str) -> bool {
     HOP_HEADERS
         .iter()
         .any(|item| item.eq_ignore_ascii_case(header))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_stream_response;
+    use axum::http::StatusCode;
+
+    #[test]
+    fn should_stream_response_requires_stream_request() {
+        assert!(!should_stream_response(false, StatusCode::OK));
+    }
+
+    #[test]
+    fn should_stream_response_requires_success_status() {
+        assert!(!should_stream_response(true, StatusCode::BAD_REQUEST));
+        assert!(!should_stream_response(
+            true,
+            StatusCode::INTERNAL_SERVER_ERROR
+        ));
+    }
+
+    #[test]
+    fn should_stream_response_allows_successful_stream_request() {
+        assert!(should_stream_response(true, StatusCode::OK));
+    }
 }

--- a/src/model_api_provider/provider.rs
+++ b/src/model_api_provider/provider.rs
@@ -178,7 +178,7 @@ pub async fn proxy_request(
     }
 }
 
-fn should_stream_response(is_stream_request: bool, status: StatusCode) -> bool {
+pub(crate) fn should_stream_response(is_stream_request: bool, status: StatusCode) -> bool {
     is_stream_request && status.is_success()
 }
 

--- a/src/model_api_provider/providers/generate_content.rs
+++ b/src/model_api_provider/providers/generate_content.rs
@@ -1,14 +1,13 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use axum::http::StatusCode;
 use futures_util::StreamExt;
 use serde_json::Value;
 
 use crate::llm_provider::vertexai::client::VertexAIClient;
 use crate::model_api_provider::provider::{
     ModelApiProvider, ProviderBody, ProviderRequest, ProviderResponse, filter_request_headers,
-    filter_response_headers, parse_stream_flag,
+    filter_response_headers, parse_stream_flag, should_stream_response,
 };
 use crate::serve_config::{ConfigError, ProviderConfig};
 
@@ -90,10 +89,6 @@ impl<M> ModelApiProvider<M> for GenerateContentClient {
     }
 }
 
-fn should_stream_response(stream_requested: bool, status: StatusCode) -> bool {
-    stream_requested && status.is_success()
-}
-
 fn extract_request_id_json(payload_json: &Value) -> Option<String> {
     payload_json
         .get("id")
@@ -139,10 +134,7 @@ fn non_null_usage(value: Option<&Value>) -> Option<Value> {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        extract_request_id_json, extract_usage_json, inject_usage_json, should_stream_response,
-    };
-    use axum::http::StatusCode;
+    use super::{extract_request_id_json, extract_usage_json, inject_usage_json};
     use serde_json::json;
 
     /// Verifies full payload request id extraction prefers top-level `id`.
@@ -195,25 +187,6 @@ mod tests {
 
         assert!(injected);
         assert_eq!(payload["response"]["usageMetadata"], new_usage);
-    }
-
-    #[test]
-    fn should_stream_response_requires_stream_request() {
-        assert!(!should_stream_response(false, StatusCode::OK));
-    }
-
-    #[test]
-    fn should_stream_response_requires_success_status() {
-        assert!(!should_stream_response(true, StatusCode::BAD_REQUEST));
-        assert!(!should_stream_response(
-            true,
-            StatusCode::INTERNAL_SERVER_ERROR
-        ));
-    }
-
-    #[test]
-    fn should_stream_response_allows_successful_stream_request() {
-        assert!(should_stream_response(true, StatusCode::OK));
     }
 }
 

--- a/src/model_api_provider/providers/generate_content.rs
+++ b/src/model_api_provider/providers/generate_content.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use axum::http::StatusCode;
 use futures_util::StreamExt;
 use serde_json::Value;
 
@@ -39,16 +40,22 @@ impl<M> ModelApiProvider<M> for GenerateContentClient {
         req: ProviderRequest,
         _metadata: &M,
     ) -> Result<ProviderResponse, anyhow::Error> {
-        let stream = parse_stream_flag(&req.body);
+        let stream_requested = parse_stream_flag(&req.body);
         let headers = filter_request_headers(req.headers);
         let response = self
             .client
-            .post_json_with_headers(&self.upstream_model, req.body.to_vec(), stream, headers)
+            .post_json_with_headers(
+                &self.upstream_model,
+                req.body.to_vec(),
+                stream_requested,
+                headers,
+            )
             .await?;
         let status = response.status();
         let mut resp_headers = filter_response_headers(response.headers());
+        let is_stream_response = should_stream_response(stream_requested, status);
 
-        if stream {
+        if is_stream_response {
             resp_headers.remove(axum::http::header::CONTENT_LENGTH);
             let body_stream = response.bytes_stream().map(|chunk| match chunk {
                 Ok(bytes) => Ok(bytes),
@@ -81,6 +88,10 @@ impl<M> ModelApiProvider<M> for GenerateContentClient {
     fn inject_usage(&self, payload_json: &mut Value, usage: Value) -> bool {
         inject_usage_json(payload_json, usage)
     }
+}
+
+fn should_stream_response(stream_requested: bool, status: StatusCode) -> bool {
+    stream_requested && status.is_success()
 }
 
 fn extract_request_id_json(payload_json: &Value) -> Option<String> {
@@ -128,7 +139,10 @@ fn non_null_usage(value: Option<&Value>) -> Option<Value> {
 
 #[cfg(test)]
 mod tests {
-    use super::{extract_request_id_json, extract_usage_json, inject_usage_json};
+    use super::{
+        extract_request_id_json, extract_usage_json, inject_usage_json, should_stream_response,
+    };
+    use axum::http::StatusCode;
     use serde_json::json;
 
     /// Verifies full payload request id extraction prefers top-level `id`.
@@ -181,6 +195,25 @@ mod tests {
 
         assert!(injected);
         assert_eq!(payload["response"]["usageMetadata"], new_usage);
+    }
+
+    #[test]
+    fn should_stream_response_requires_stream_request() {
+        assert!(!should_stream_response(false, StatusCode::OK));
+    }
+
+    #[test]
+    fn should_stream_response_requires_success_status() {
+        assert!(!should_stream_response(true, StatusCode::BAD_REQUEST));
+        assert!(!should_stream_response(
+            true,
+            StatusCode::INTERNAL_SERVER_ERROR
+        ));
+    }
+
+    #[test]
+    fn should_stream_response_allows_successful_stream_request() {
+        assert!(should_stream_response(true, StatusCode::OK));
     }
 }
 


### PR DESCRIPTION
## Summary
- avoid treating non-2xx upstream responses as streaming payloads in model API proxy paths
- align `generate_content` with the same stream gating rule (`stream_requested && status.is_success()`)
- add focused unit tests for stream response decision logic