### PR TITLE
fix: normalize GPT-5.6 tool requests

### DIFF
--- a/src/llm_provider/openai.rs
+++ b/src/llm_provider/openai.rs
@@ -157,7 +157,14 @@ fn normalize_gpt5_request(request: &mut ChatCompletionRequest) {
 fn is_target_gpt5_model(model: &str) -> bool {
     matches!(
         model,
-        "gpt-5.5" | "gpt-5.5-1" | "gpt-5.4" | "gpt-5.4-mini" | "gpt-5.4-nano"
+        "gpt-5.5"
+            | "gpt-5.5-1"
+            | "gpt-5.4"
+            | "gpt-5.4-mini"
+            | "gpt-5.4-nano"
+            | "gpt-5.6-sol"
+            | "gpt-5.6-luna"
+            | "gpt-5.6-terra"
     )
 }
 
@@ -272,6 +279,25 @@ mod tests {
     #[test]
     fn normalize_gpt5_clears_reasoning_effort_when_tools_present() {
         let mut request = base_request("gpt-5.4-mini");
+        request.reasoning_effort = Some("medium".to_string());
+        request.tools = Some(vec![ToolDefinition {
+            r#type: "function".to_string(),
+            function: FunctionDefinition {
+                name: "test_tool".to_string(),
+                description: None,
+                strict: None,
+                parameters: json!({}),
+            },
+        }]);
+
+        normalize_gpt5_request(&mut request);
+
+        assert!(request.reasoning_effort.is_none());
+    }
+
+    #[test]
+    fn normalize_gpt56_clears_reasoning_effort_when_tools_present() {
+        let mut request = base_request("gpt-5.6-luna");
         request.reasoning_effort = Some("medium".to_string());
         request.tools = Some(vec![ToolDefinition {
             r#type: "function".to_string(),

--- a/src/llm_provider/openai.rs
+++ b/src/llm_provider/openai.rs
@@ -296,22 +296,15 @@ mod tests {
     }
 
     #[test]
-    fn normalize_gpt56_clears_reasoning_effort_when_tools_present() {
-        let mut request = base_request("gpt-5.6-luna");
-        request.reasoning_effort = Some("medium".to_string());
-        request.tools = Some(vec![ToolDefinition {
-            r#type: "function".to_string(),
-            function: FunctionDefinition {
-                name: "test_tool".to_string(),
-                description: None,
-                strict: None,
-                parameters: json!({}),
-            },
-        }]);
+    fn is_target_gpt5_model_includes_gpt56_models() {
+        for model in ["gpt-5.6-sol", "gpt-5.6-luna", "gpt-5.6-terra"] {
+            assert!(
+                is_target_gpt5_model(model),
+                "expected {model} to be a target"
+            );
+        }
 
-        normalize_gpt5_request(&mut request);
-
-        assert!(request.reasoning_effort.is_none());
+        assert!(!is_target_gpt5_model("gpt-5.6-unknown"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add GPT-5.6 Sol, Luna, and Terra to the OpenAI request normalization list
- remove reasoning_effort when these models are used with function tools

## Testing
- cargo fmt --check
- cargo check
- cargo test normalize_gpt56