### PR TITLE
fix: return 403 on access denied selection

### DIFF
--- a/src/llm_api.rs
+++ b/src/llm_api.rs
@@ -167,6 +167,15 @@ where
         .select(request_model_id.as_deref(), &metadata)
     {
         Ok(provider_entry) => provider_entry,
+        Err(SelectionError::AccessDenied) => {
+            let response = openai_error_response(
+                StatusCode::FORBIDDEN,
+                "access_denied",
+                Some("access_denied"),
+            );
+            set_http_span_status(&root_span, response.status(), Some("access_denied"));
+            return Ok(response);
+        }
         Err(SelectionError::OutstandingBalance) => {
             let response = openai_error_response(
                 StatusCode::PAYMENT_REQUIRED,
@@ -209,7 +218,7 @@ where
         }
     }
     info!(
-        "http.request.start; method=POST path=/v1/chat/completion model_id={} stream={} trace_id={} metadata={:?}",
+        "http.request.start; method=POST path=/v1/chat/completions model_id={} stream={} trace_id={} metadata={:?}",
         request_model_id
             .as_deref()
             .unwrap_or(&provider_entry.model_id),

--- a/src/llm_provider/selection.rs
+++ b/src/llm_provider/selection.rs
@@ -7,6 +7,7 @@ pub struct SelectionResult {
 pub enum SelectionError {
     ModelNotSupported,
     OutstandingBalance,
+    AccessDenied,
 }
 
 pub trait SelectionStrategy<M>: Send + Sync {

--- a/src/model_api.rs
+++ b/src/model_api.rs
@@ -147,6 +147,14 @@ where
         &metadata,
     ) {
         Ok(provider_entry) => provider_entry,
+        Err(SelectionError::AccessDenied) => {
+            set_http_span_status(&root_span, StatusCode::FORBIDDEN, Some("access_denied"));
+            return openai_error_response(
+                StatusCode::FORBIDDEN,
+                "access_denied",
+                Some("access_denied"),
+            );
+        }
         Err(SelectionError::OutstandingBalance) => {
             set_http_span_status(
                 &root_span,

--- a/src/model_api_provider/selection.rs
+++ b/src/model_api_provider/selection.rs
@@ -3,11 +3,7 @@ pub struct SelectionResult {
     pub model_id: String,
 }
 
-#[derive(Debug)]
-pub enum SelectionError {
-    ModelNotSupported,
-    OutstandingBalance,
-}
+pub use crate::llm_provider::selection::SelectionError;
 
 pub trait SelectionStrategy<M>: Send + Sync {
     fn select(


### PR DESCRIPTION
## What
- add SelectionError::AccessDenied to provider selection errors
- return HTTP 403 access_denied for chat completions when selection is denied
- return HTTP 403 access_denied for model API endpoints when selection is denied
- reuse SelectionError type in model API provider selection to keep behavior consistent
- fix request-start log path to /v1/chat/completions

## Verification
- cargo fmt
- cargo check