### PR TITLE
feat: add anthropic/bedrock messages LLM providers

### DIFF
--- a/src/llm_provider/anthropic_messages/client.rs
+++ b/src/llm_provider/anthropic_messages/client.rs
@@ -2,6 +2,7 @@ use std::pin::Pin;
 
 use async_stream::try_stream;
 use aws_sdk_bedrockruntime::config::{BehaviorVersion, Token};
+use aws_sdk_bedrockruntime::error::SdkError;
 use aws_sdk_bedrockruntime::primitives::Blob;
 use aws_types::region::Region;
 use axum::http::StatusCode;
@@ -195,9 +196,7 @@ impl BedrockClient {
             .body(Blob::new(body))
             .send()
             .await
-            .map_err(|err| {
-                ClientError::Internal(format!("bedrock invoke_model failed: {err:?}"))
-            })?;
+            .map_err(|err| map_bedrock_invoke_error(err, "bedrock invoke_model failed"))?;
 
         serde_json::from_slice::<AnthropicResponse>(&response.body.into_inner())
             .map_err(|err| ClientError::Parse(err.to_string()))
@@ -218,9 +217,7 @@ impl BedrockClient {
             .body(Blob::new(body))
             .send()
             .await
-            .map_err(|err| {
-                ClientError::Internal(format!("bedrock stream invoke failed: {err:?}"))
-            })?;
+            .map_err(|err| map_bedrock_invoke_error(err, "bedrock stream invoke failed"))?;
 
         let mut stream = response.body;
         Ok(Box::pin(try_stream! {
@@ -305,4 +302,113 @@ fn default_error_type(status: StatusCode) -> &'static str {
         return "invalid_request_error";
     }
     "internal_error"
+}
+
+fn map_bedrock_invoke_error<E>(err: SdkError<E>, context: &str) -> ClientError
+where
+    E: std::error::Error + Send + Sync + 'static,
+{
+    passthrough_bad_request(&err)
+        .unwrap_or_else(|| ClientError::Internal(format!("{context}: {err:?}")))
+}
+
+fn passthrough_bad_request<E>(err: &SdkError<E>) -> Option<ClientError>
+where
+    E: std::error::Error + Send + Sync + 'static,
+{
+    let raw_response = err.raw_response()?;
+    let status = StatusCode::from_u16(raw_response.status().as_u16()).ok()?;
+    let payload = raw_response.body().bytes();
+
+    passthrough_bad_request_response(status, payload)
+}
+
+fn passthrough_bad_request_response(
+    status: StatusCode,
+    payload: Option<&[u8]>,
+) -> Option<ClientError> {
+    if status != StatusCode::BAD_REQUEST {
+        return None;
+    }
+
+    let status = reqwest::StatusCode::from_u16(status.as_u16()).ok()?;
+    let payload = payload.unwrap_or_default();
+    Some(parse_api_error(status, payload))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ClientError, map_client_error, passthrough_bad_request_response};
+    use crate::llm_provider::ProviderError;
+    use crate::openai_types::ErrorDetail;
+    use axum::http::StatusCode;
+
+    #[test]
+    fn passthrough_bad_request_response_maps_json_message() {
+        let payload = br#"{"message":"adaptive thinking is not supported on this model"}"#;
+
+        let err = passthrough_bad_request_response(StatusCode::BAD_REQUEST, Some(payload));
+
+        let Some(ClientError::Api { status, error }) = err else {
+            panic!("expected api error");
+        };
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(
+            error.message,
+            "adaptive thinking is not supported on this model"
+        );
+        assert_eq!(error.r#type, "invalid_request_error");
+    }
+
+    #[test]
+    fn passthrough_bad_request_response_ignores_non_bad_request() {
+        let payload = br#"{"message":"upstream error"}"#;
+
+        let err =
+            passthrough_bad_request_response(StatusCode::INTERNAL_SERVER_ERROR, Some(payload));
+
+        assert!(err.is_none());
+    }
+
+    #[test]
+    fn map_client_error_passthroughs_bad_request_for_direct_client() {
+        let err = map_client_error(ClientError::Api {
+            status: StatusCode::BAD_REQUEST,
+            error: ErrorDetail {
+                message: "unsupported request".to_string(),
+                r#type: "invalid_request_error".to_string(),
+                code: None,
+                param: None,
+            },
+        });
+
+        let ProviderError::Public { status, error } = err else {
+            panic!("expected public provider error");
+        };
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(error.message, "unsupported request");
+    }
+
+    #[test]
+    fn map_client_error_keeps_non_bad_request_as_internal() {
+        let err = map_client_error(ClientError::Api {
+            status: StatusCode::TOO_MANY_REQUESTS,
+            error: ErrorDetail {
+                message: "rate limited".to_string(),
+                r#type: "rate_limit_error".to_string(),
+                code: None,
+                param: None,
+            },
+        });
+
+        let ProviderError::Internal {
+            upstream_http_status,
+            message,
+        } = err
+        else {
+            panic!("expected internal provider error");
+        };
+        assert_eq!(upstream_http_status, StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(message, "rate limited");
+    }
 }

--- a/src/llm_provider/anthropic_messages/client.rs
+++ b/src/llm_provider/anthropic_messages/client.rs
@@ -1,0 +1,308 @@
+use std::pin::Pin;
+
+use async_stream::try_stream;
+use aws_sdk_bedrockruntime::config::{BehaviorVersion, Token};
+use aws_sdk_bedrockruntime::primitives::Blob;
+use aws_types::region::Region;
+use axum::http::StatusCode;
+use futures_core::Stream;
+use futures_util::StreamExt;
+use serde_json::Value;
+
+use crate::llm_provider::ProviderError;
+use crate::openai_types::ErrorDetail;
+use crate::serve_config::ConfigError;
+
+use super::types::{
+    AnthropicErrorEnvelope, AnthropicRequest, AnthropicResponse, BedrockRequest, StreamEvent,
+};
+
+#[derive(Clone)]
+pub(super) enum Backend {
+    Direct(DirectClient),
+    Bedrock(BedrockClient),
+}
+
+#[derive(Clone)]
+pub(super) struct DirectClient {
+    pub client: reqwest::Client,
+    pub base_url: String,
+    pub auth_style: AuthStyle,
+    pub api_key: String,
+}
+
+#[derive(Clone)]
+pub(super) struct BedrockClient {
+    pub model_id: String,
+    pub aws_region: String,
+    pub aws_bearer_token: String,
+}
+
+#[derive(Clone, Copy)]
+pub(super) enum AuthStyle {
+    XApiKey,
+    Bearer,
+}
+
+pub(super) fn parse_auth_style(value: Option<&String>) -> Result<AuthStyle, ConfigError> {
+    let style = value.cloned().unwrap_or_else(|| "x-api-key".to_string());
+    match style.as_str() {
+        "x-api-key" => Ok(AuthStyle::XApiKey),
+        "bearer" => Ok(AuthStyle::Bearer),
+        other => Err(ConfigError::InvalidProvider(format!(
+            "unknown auth_style: {}",
+            other
+        ))),
+    }
+}
+
+#[derive(Debug)]
+pub(super) enum ClientError {
+    Http(reqwest::Error),
+    Parse(String),
+    Api {
+        status: StatusCode,
+        error: ErrorDetail,
+    },
+    Internal(String),
+}
+
+impl std::fmt::Display for ClientError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ClientError::Http(err) => write!(f, "http error: {err}"),
+            ClientError::Parse(err) => write!(f, "parse error: {err}"),
+            ClientError::Api { status, error } => {
+                write!(f, "api error {status}: {}", error.message)
+            }
+            ClientError::Internal(err) => write!(f, "internal error: {err}"),
+        }
+    }
+}
+
+impl From<reqwest::Error> for ClientError {
+    fn from(value: reqwest::Error) -> Self {
+        Self::Http(value)
+    }
+}
+
+pub(super) fn map_client_error(err: ClientError) -> ProviderError {
+    match err {
+        ClientError::Api { status, error } if status == StatusCode::BAD_REQUEST => {
+            ProviderError::Public { status, error }
+        }
+        ClientError::Api { status, error } => {
+            ProviderError::internal_with_upstream_status(status, error.message)
+        }
+        other => ProviderError::internal(other.to_string()),
+    }
+}
+
+impl DirectClient {
+    pub(super) async fn send_complete(
+        &self,
+        request: AnthropicRequest,
+        anthropic_version: &str,
+    ) -> Result<AnthropicResponse, ClientError> {
+        let mut builder = self
+            .client
+            .post(format!("{}/messages", self.base_url.trim_end_matches('/')))
+            .header("anthropic-version", anthropic_version)
+            .header(reqwest::header::CONTENT_TYPE, "application/json");
+        builder = match self.auth_style {
+            AuthStyle::XApiKey => builder.header("x-api-key", self.api_key.as_str()),
+            AuthStyle::Bearer => builder.bearer_auth(&self.api_key),
+        };
+
+        let response = builder.json(&request).send().await?;
+        let status = response.status();
+        let bytes = response.bytes().await?;
+        if !status.is_success() {
+            return Err(parse_api_error(status, &bytes));
+        }
+        serde_json::from_slice::<AnthropicResponse>(&bytes)
+            .map_err(|err| ClientError::Parse(err.to_string()))
+    }
+
+    pub(super) async fn send_stream(
+        &self,
+        request: AnthropicRequest,
+        anthropic_version: &str,
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamEvent, ProviderError>> + Send>>, ClientError>
+    {
+        let mut builder = self
+            .client
+            .post(format!("{}/messages", self.base_url.trim_end_matches('/')))
+            .header("anthropic-version", anthropic_version)
+            .header(reqwest::header::CONTENT_TYPE, "application/json");
+        builder = match self.auth_style {
+            AuthStyle::XApiKey => builder.header("x-api-key", self.api_key.as_str()),
+            AuthStyle::Bearer => builder.bearer_auth(&self.api_key),
+        };
+
+        let response = builder.json(&request).send().await?;
+        let status = response.status();
+        if !status.is_success() {
+            let bytes = response.bytes().await?;
+            return Err(parse_api_error(status, &bytes));
+        }
+
+        let stream = response.bytes_stream();
+        Ok(Box::pin(try_stream! {
+            futures_util::pin_mut!(stream);
+            let mut buffer = String::new();
+            while let Some(item) = stream.next().await {
+                let chunk = item.map_err(ClientError::from).map_err(map_client_error)?;
+                let text = String::from_utf8_lossy(&chunk);
+                buffer.push_str(&text);
+
+                while let Some(pos) = buffer.find('\n') {
+                    let line = buffer[..pos].trim().to_string();
+                    buffer.drain(..=pos);
+
+                    if line.is_empty() || line.starts_with("event:") {
+                        continue;
+                    }
+                    if let Some(data) = line.strip_prefix("data:") {
+                        let payload = data.trim();
+                        if payload.is_empty() || payload == "[DONE]" {
+                            continue;
+                        }
+                        let event: StreamEvent = serde_json::from_str(payload).map_err(|err| {
+                            ProviderError::internal(format!("parse anthropic stream event: {err}"))
+                        })?;
+                        yield event;
+                    }
+                }
+            }
+        }))
+    }
+}
+
+impl BedrockClient {
+    pub(super) async fn send_complete(
+        &self,
+        request: BedrockRequest,
+    ) -> Result<AnthropicResponse, ClientError> {
+        let client = self.client().await?;
+        let body =
+            serde_json::to_vec(&request).map_err(|err| ClientError::Parse(err.to_string()))?;
+        let response = client
+            .invoke_model()
+            .model_id(&self.model_id)
+            .content_type("application/json")
+            .accept("application/json")
+            .body(Blob::new(body))
+            .send()
+            .await
+            .map_err(|err| {
+                ClientError::Internal(format!("bedrock invoke_model failed: {err:?}"))
+            })?;
+
+        serde_json::from_slice::<AnthropicResponse>(&response.body.into_inner())
+            .map_err(|err| ClientError::Parse(err.to_string()))
+    }
+
+    pub(super) async fn send_stream(
+        &self,
+        request: BedrockRequest,
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamEvent, ProviderError>> + Send>>, ClientError>
+    {
+        let client = self.client().await?;
+        let body =
+            serde_json::to_vec(&request).map_err(|err| ClientError::Parse(err.to_string()))?;
+        let response = client
+            .invoke_model_with_response_stream()
+            .model_id(&self.model_id)
+            .content_type("application/json")
+            .body(Blob::new(body))
+            .send()
+            .await
+            .map_err(|err| {
+                ClientError::Internal(format!("bedrock stream invoke failed: {err:?}"))
+            })?;
+
+        let mut stream = response.body;
+        Ok(Box::pin(try_stream! {
+            loop {
+                match stream.recv().await {
+                    Ok(Some(event)) => {
+                        if let Ok(chunk) = event.as_chunk() {
+                            if let Some(payload) = chunk.bytes.as_ref() {
+                                let parsed = serde_json::from_slice::<StreamEvent>(payload.as_ref())
+                                    .map_err(|err| ProviderError::internal(format!("parse bedrock stream event: {err}")))?;
+                                yield parsed;
+                            }
+                        }
+                    }
+                    Ok(None) => break,
+                    Err(err) => {
+                        Err(ProviderError::internal(format!("bedrock stream recv failed: {err}")))?
+                    }
+                }
+            }
+        }))
+    }
+
+    async fn client(&self) -> Result<aws_sdk_bedrockruntime::Client, ClientError> {
+        let config = aws_sdk_bedrockruntime::Config::builder()
+            .behavior_version(BehaviorVersion::latest())
+            .region(Region::new(self.aws_region.clone()))
+            .bearer_token(Token::new(&self.aws_bearer_token, None))
+            .build();
+        Ok(aws_sdk_bedrockruntime::Client::from_conf(config))
+    }
+}
+
+fn parse_api_error(status: reqwest::StatusCode, bytes: &[u8]) -> ClientError {
+    if let Ok(envelope) = serde_json::from_slice::<AnthropicErrorEnvelope>(bytes) {
+        return ClientError::Api {
+            status,
+            error: ErrorDetail {
+                message: envelope.error.message,
+                r#type: envelope
+                    .error
+                    .r#type
+                    .unwrap_or_else(|| default_error_type(status).to_string()),
+                code: None,
+                param: None,
+            },
+        };
+    }
+
+    if let Ok(value) = serde_json::from_slice::<Value>(bytes) {
+        let message = value
+            .get("error")
+            .and_then(|error| error.get("message"))
+            .and_then(Value::as_str)
+            .or_else(|| value.get("message").and_then(Value::as_str))
+            .unwrap_or("unknown anthropic error")
+            .to_string();
+        return ClientError::Api {
+            status,
+            error: ErrorDetail {
+                message,
+                r#type: default_error_type(status).to_string(),
+                code: None,
+                param: None,
+            },
+        };
+    }
+
+    ClientError::Api {
+        status,
+        error: ErrorDetail {
+            message: String::from_utf8_lossy(bytes).to_string(),
+            r#type: default_error_type(status).to_string(),
+            code: None,
+            param: None,
+        },
+    }
+}
+
+fn default_error_type(status: StatusCode) -> &'static str {
+    if status == StatusCode::BAD_REQUEST {
+        return "invalid_request_error";
+    }
+    "internal_error"
+}

--- a/src/llm_provider/anthropic_messages/mapper.rs
+++ b/src/llm_provider/anthropic_messages/mapper.rs
@@ -113,6 +113,7 @@ pub(super) fn map_request(
     });
 
     let thinking = map_thinking(
+        &upstream_model,
         request.thinking.as_ref(),
         request.reasoning_effort.as_deref(),
     );
@@ -349,9 +350,14 @@ fn map_regular_content(content: &Content) -> Result<Vec<AnthropicContentBlock>, 
 }
 
 fn map_thinking(
+    model: &str,
     thinking: Option<&crate::openai_types::ThinkingConfig>,
     reasoning_effort: Option<&str>,
 ) -> Option<AnthropicThinking> {
+    if is_thinking_unsupported_model(model) {
+        return None;
+    }
+
     if let Some(config) = thinking {
         return match config.kind {
             crate::openai_types::ThinkingType::Enabled => Some(AnthropicThinking::Enabled {
@@ -367,6 +373,10 @@ fn map_thinking(
     }
 
     None
+}
+
+fn is_thinking_unsupported_model(model: &str) -> bool {
+    model.to_ascii_lowercase().contains("claude-haiku")
 }
 
 fn extract_text_from_content(content: &Content) -> String {

--- a/src/llm_provider/anthropic_messages/mapper.rs
+++ b/src/llm_provider/anthropic_messages/mapper.rs
@@ -39,9 +39,9 @@ pub(super) fn map_request(
             Role::Assistant => {
                 let mut blocks = map_regular_content(&message.content)?;
                 if let Some(tool_calls) = message.tool_calls {
-                    for call in tool_calls {
+                    for (index, call) in tool_calls.into_iter().enumerate() {
                         let id = call.id.unwrap_or_else(|| {
-                            format!("toolu_{}", uuid_suffix(&call.function.name))
+                            format!("toolu_{}_{}", uuid_suffix(&call.function.name), index)
                         });
                         let input = serde_json::from_str::<Value>(&call.function.arguments)
                             .unwrap_or_else(|_| json!({"input": call.function.arguments}));
@@ -283,7 +283,7 @@ pub(super) fn map_stream_event(event: StreamEvent, state: &mut StreamState) -> V
             }
         }
         StreamEvent::MessageStop => {
-            if state.started {
+            if state.started && !state.completed {
                 let stop_reason = state
                     .stop_reason
                     .clone()
@@ -295,6 +295,7 @@ pub(super) fn map_stream_event(event: StreamEvent, state: &mut StreamState) -> V
                 out.push(UnifiedEvent::Completed {
                     finish_reason: Some(map_stop_reason_string(&stop_reason).to_string()),
                 });
+                state.completed = true;
             }
         }
         StreamEvent::Ping | StreamEvent::Unknown => {}

--- a/src/llm_provider/anthropic_messages/mapper.rs
+++ b/src/llm_provider/anthropic_messages/mapper.rs
@@ -1,3 +1,4 @@
+use log::warn;
 use serde_json::{Value, json};
 
 use crate::llm_provider::{FinishReason, ProviderError, ToolCall, UnifiedEvent, UnifiedResponse};
@@ -153,6 +154,12 @@ pub(super) fn map_response(response: AnthropicResponse) -> UnifiedResponse {
         }
     }
 
+    if response.usage.is_none() {
+        warn!(
+            "anthropic messages upstream response missing usage; model={} request_id={}",
+            response.model, response.id
+        );
+    }
     let usage = EndpointUsage::Messages(response.usage.unwrap_or(MessagesUsage {
         input_tokens: None,
         output_tokens: None,
@@ -277,6 +284,7 @@ pub(super) fn map_stream_event(event: StreamEvent, state: &mut StreamState) -> V
                 state.stop_reason = delta.stop_reason;
             }
             if let Some(usage) = usage {
+                state.usage_received = true;
                 out.push(UnifiedEvent::Usage {
                     usage: EndpointUsage::Messages(usage),
                 });

--- a/src/llm_provider/anthropic_messages/mapper.rs
+++ b/src/llm_provider/anthropic_messages/mapper.rs
@@ -1,0 +1,393 @@
+use serde_json::{Value, json};
+
+use crate::llm_provider::{FinishReason, ProviderError, ToolCall, UnifiedEvent, UnifiedResponse};
+use crate::model_api_provider::MessagesUsage;
+use crate::openai_types::{ChatCompletionRequest, Content, ContentPart, Role, ToolChoice};
+use crate::usage_handler::EndpointUsage;
+
+use super::types::{
+    ActiveBlock, AnthropicContentBlock, AnthropicImageSource, AnthropicMessage, AnthropicResponse,
+    AnthropicResponseContentBlock, AnthropicThinking, AnthropicTool, AnthropicToolChoice,
+    RequestParts, StreamContentBlock, StreamContentDelta, StreamEvent, StreamState,
+};
+
+pub(super) fn map_request(
+    request: ChatCompletionRequest,
+    upstream_model: String,
+    default_max_tokens: i32,
+) -> Result<RequestParts, ProviderError> {
+    let mut system_chunks = Vec::<String>::new();
+    let mut messages = Vec::<AnthropicMessage>::new();
+
+    for message in request.messages {
+        match message.role {
+            Role::System | Role::Developer => {
+                let text = extract_text_from_content(&message.content);
+                if !text.trim().is_empty() {
+                    system_chunks.push(text);
+                }
+            }
+            Role::User => {
+                let blocks = map_regular_content(&message.content)?;
+                messages.push(AnthropicMessage {
+                    role: "user".to_string(),
+                    content: blocks,
+                });
+            }
+            Role::Assistant => {
+                let mut blocks = map_regular_content(&message.content)?;
+                if let Some(tool_calls) = message.tool_calls {
+                    for call in tool_calls {
+                        let id = call.id.unwrap_or_else(|| {
+                            format!("toolu_{}", uuid_suffix(&call.function.name))
+                        });
+                        let input = serde_json::from_str::<Value>(&call.function.arguments)
+                            .unwrap_or_else(|_| json!({"input": call.function.arguments}));
+                        blocks.push(AnthropicContentBlock::ToolUse {
+                            id,
+                            name: call.function.name,
+                            input,
+                        });
+                    }
+                }
+                if blocks.is_empty() {
+                    blocks.push(AnthropicContentBlock::Text {
+                        text: String::new(),
+                    });
+                }
+                messages.push(AnthropicMessage {
+                    role: "assistant".to_string(),
+                    content: blocks,
+                });
+            }
+            Role::Tool => {
+                let tool_use_id = message
+                    .tool_call_id
+                    .clone()
+                    .filter(|id| !id.trim().is_empty())
+                    .ok_or_else(|| {
+                        ProviderError::internal("tool_call_id is required for tool messages")
+                    })?;
+                let result_text = extract_text_from_content(&message.content);
+                messages.push(AnthropicMessage {
+                    role: "user".to_string(),
+                    content: vec![AnthropicContentBlock::ToolResult {
+                        tool_use_id,
+                        content: vec![AnthropicContentBlock::Text { text: result_text }],
+                        is_error: None,
+                    }],
+                });
+            }
+        }
+    }
+
+    let tools = request.tools.map(|tools| {
+        tools
+            .into_iter()
+            .map(|tool| AnthropicTool {
+                name: tool.function.name,
+                description: tool.function.description,
+                input_schema: tool.function.parameters,
+            })
+            .collect::<Vec<_>>()
+    });
+
+    let disable_parallel_tool_use = request.parallel_tool_calls.map(|parallel| !parallel);
+    let tool_choice = request.tool_choice.as_ref().map(|choice| match choice {
+        ToolChoice::Name(name) if name == "auto" => AnthropicToolChoice::Auto {
+            disable_parallel_tool_use,
+        },
+        ToolChoice::Name(name) if name == "required" => AnthropicToolChoice::Any {
+            disable_parallel_tool_use,
+        },
+        ToolChoice::Name(name) if name == "none" => AnthropicToolChoice::None,
+        ToolChoice::Object { function, .. } => AnthropicToolChoice::Tool {
+            name: function.name.clone(),
+            disable_parallel_tool_use,
+        },
+        _ => AnthropicToolChoice::Auto {
+            disable_parallel_tool_use,
+        },
+    });
+
+    let thinking = map_thinking(
+        request.thinking.as_ref(),
+        request.reasoning_effort.as_deref(),
+    );
+
+    Ok(RequestParts {
+        model: upstream_model,
+        max_tokens: request.max_completion_tokens.unwrap_or(default_max_tokens),
+        messages,
+        system: (!system_chunks.is_empty()).then(|| system_chunks.join("\n")),
+        temperature: request.temperature,
+        top_p: request.top_p,
+        stop_sequences: request.stop,
+        tools,
+        tool_choice,
+        thinking,
+    })
+}
+
+pub(super) fn map_response(response: AnthropicResponse) -> UnifiedResponse {
+    let mut output_text = String::new();
+    let mut reasoning_content = String::new();
+    let mut tool_calls = Vec::new();
+
+    for block in response.content {
+        match block {
+            AnthropicResponseContentBlock::Text { text } => output_text.push_str(&text),
+            AnthropicResponseContentBlock::Thinking { thinking } => {
+                reasoning_content.push_str(&thinking)
+            }
+            AnthropicResponseContentBlock::ToolUse { id, name, input } => {
+                tool_calls.push(ToolCall {
+                    id: Some(id),
+                    name,
+                    description: String::new(),
+                    arguments: input.to_string(),
+                });
+            }
+            AnthropicResponseContentBlock::Unknown => {}
+        }
+    }
+
+    let usage = EndpointUsage::Messages(response.usage.unwrap_or(MessagesUsage {
+        input_tokens: None,
+        output_tokens: None,
+        cache_creation_input_tokens: None,
+        cache_read_input_tokens: None,
+        cache_creation: None,
+        inference_geo: None,
+        service_tier: None,
+        server_tool_use: None,
+    }));
+
+    UnifiedResponse {
+        request_id: response.id,
+        created_at: chrono::Utc::now().to_rfc3339(),
+        model: response.model,
+        output_text,
+        reasoning_content: (!reasoning_content.is_empty()).then_some(reasoning_content),
+        tool_calls: (!tool_calls.is_empty()).then_some(tool_calls),
+        finish_reason: map_finish_reason(response.stop_reason.as_deref()),
+        usage,
+    }
+}
+
+pub(super) fn map_stream_event(event: StreamEvent, state: &mut StreamState) -> Vec<UnifiedEvent> {
+    let mut out = Vec::new();
+
+    match event {
+        StreamEvent::MessageStart { message } => {
+            state.response_id = message.id;
+            state.model = message.model;
+            state.created_at = chrono::Utc::now().to_rfc3339();
+            state.started = true;
+            out.push(UnifiedEvent::ResponseCreated {
+                id: state.response_id.clone(),
+                model: state.model.clone(),
+                created_at: state.created_at.clone(),
+            });
+            out.push(UnifiedEvent::ResponseInProgress {
+                id: state.response_id.clone(),
+                model: state.model.clone(),
+                created_at: state.created_at.clone(),
+            });
+            out.push(UnifiedEvent::MessageStart {
+                id: state.response_id.clone(),
+                role: "assistant".to_string(),
+            });
+        }
+        StreamEvent::ContentBlockStart {
+            index,
+            content_block,
+        } => match content_block {
+            StreamContentBlock::ToolUse { id, name, input } => {
+                let arguments = input.to_string();
+                state.blocks.insert(
+                    index,
+                    ActiveBlock::ToolUse {
+                        id: id.clone(),
+                        name: name.clone(),
+                        arguments: arguments.clone(),
+                    },
+                );
+                if arguments != "{}" {
+                    out.push(UnifiedEvent::ToolCallDelta {
+                        id,
+                        name,
+                        arguments_delta: arguments,
+                    });
+                }
+            }
+            _ => {
+                state.blocks.insert(index, ActiveBlock::Other);
+            }
+        },
+        StreamEvent::ContentBlockDelta { index, delta } => match delta {
+            StreamContentDelta::TextDelta { text } => {
+                out.push(UnifiedEvent::MessageDelta {
+                    id: state.response_id.clone(),
+                    delta: text,
+                });
+            }
+            StreamContentDelta::ThinkingDelta { thinking } => {
+                out.push(UnifiedEvent::ThinkingDelta {
+                    id: state.response_id.clone(),
+                    delta: thinking,
+                });
+            }
+            StreamContentDelta::InputJsonDelta { partial_json } => {
+                if let Some(ActiveBlock::ToolUse {
+                    id,
+                    name,
+                    arguments,
+                }) = state.blocks.get_mut(&index)
+                {
+                    arguments.push_str(&partial_json);
+                    out.push(UnifiedEvent::ToolCallDelta {
+                        id: id.clone(),
+                        name: name.clone(),
+                        arguments_delta: partial_json,
+                    });
+                }
+            }
+            StreamContentDelta::Unknown => {}
+        },
+        StreamEvent::ContentBlockStop { index } => {
+            if let Some(ActiveBlock::ToolUse {
+                id,
+                name,
+                arguments,
+            }) = state.blocks.remove(&index)
+            {
+                out.push(UnifiedEvent::ToolCallDone {
+                    id,
+                    name,
+                    arguments,
+                });
+            }
+        }
+        StreamEvent::MessageDelta { delta, usage } => {
+            if let Some(delta) = delta {
+                state.stop_reason = delta.stop_reason;
+            }
+            if let Some(usage) = usage {
+                out.push(UnifiedEvent::Usage {
+                    usage: EndpointUsage::Messages(usage),
+                });
+            }
+        }
+        StreamEvent::MessageStop => {
+            if state.started {
+                let stop_reason = state
+                    .stop_reason
+                    .clone()
+                    .unwrap_or_else(|| "end_turn".to_string());
+                out.push(UnifiedEvent::MessageStop {
+                    id: state.response_id.clone(),
+                    stop_reason: Some(map_stop_reason_string(&stop_reason).to_string()),
+                });
+                out.push(UnifiedEvent::Completed {
+                    finish_reason: Some(map_stop_reason_string(&stop_reason).to_string()),
+                });
+            }
+        }
+        StreamEvent::Ping | StreamEvent::Unknown => {}
+    }
+
+    out
+}
+
+fn map_regular_content(content: &Content) -> Result<Vec<AnthropicContentBlock>, ProviderError> {
+    match content {
+        Content::Text(text) => Ok(vec![AnthropicContentBlock::Text { text: text.clone() }]),
+        Content::Parts(parts) => {
+            let mut blocks = Vec::new();
+            for part in parts {
+                match part {
+                    ContentPart::Text { text } => {
+                        blocks.push(AnthropicContentBlock::Text { text: text.clone() });
+                    }
+                    ContentPart::Image { image_url } => {
+                        blocks.push(AnthropicContentBlock::Image {
+                            source: AnthropicImageSource::Url {
+                                url: image_url.url.clone(),
+                            },
+                        });
+                    }
+                    ContentPart::InputAudio { .. } | ContentPart::File { .. } => {
+                        return Err(ProviderError::internal(
+                            "anthropic messages provider does not support input_audio/file parts",
+                        ));
+                    }
+                }
+            }
+            Ok(blocks)
+        }
+    }
+}
+
+fn map_thinking(
+    thinking: Option<&crate::openai_types::ThinkingConfig>,
+    _reasoning_effort: Option<&str>,
+) -> Option<AnthropicThinking> {
+    if let Some(config) = thinking {
+        return match config.kind {
+            crate::openai_types::ThinkingType::Enabled => Some(AnthropicThinking::Enabled {
+                budget_tokens: 2048,
+            }),
+            crate::openai_types::ThinkingType::Adaptive => Some(AnthropicThinking::Adaptive),
+            crate::openai_types::ThinkingType::Disabled => Some(AnthropicThinking::Disabled),
+        };
+    }
+
+    None
+}
+
+fn extract_text_from_content(content: &Content) -> String {
+    match content {
+        Content::Text(text) => text.clone(),
+        Content::Parts(parts) => parts
+            .iter()
+            .filter_map(|part| match part {
+                ContentPart::Text { text } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join(""),
+    }
+}
+
+fn map_finish_reason(reason: Option<&str>) -> FinishReason {
+    match reason.unwrap_or("end_turn") {
+        "end_turn" | "stop_sequence" => FinishReason::Stop,
+        "max_tokens" => FinishReason::Length,
+        "tool_use" => FinishReason::ToolCalls,
+        "refusal" => FinishReason::ContentFilter,
+        _ => FinishReason::Other,
+    }
+}
+
+pub(super) fn map_stop_reason_string(reason: &str) -> &'static str {
+    match reason {
+        "end_turn" | "stop_sequence" => "stop",
+        "max_tokens" => "length",
+        "tool_use" => "tool_calls",
+        "refusal" => "content_filter",
+        _ => "other",
+    }
+}
+
+fn uuid_suffix(name: &str) -> String {
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        return "call".to_string();
+    }
+    trimmed
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric() || *ch == '_')
+        .take(32)
+        .collect::<String>()
+}

--- a/src/llm_provider/anthropic_messages/mapper.rs
+++ b/src/llm_provider/anthropic_messages/mapper.rs
@@ -29,10 +29,12 @@ pub(super) fn map_request(
             }
             Role::User => {
                 let blocks = map_regular_content(&message.content)?;
-                messages.push(AnthropicMessage {
-                    role: "user".to_string(),
-                    content: blocks,
-                });
+                if !blocks.is_empty() {
+                    messages.push(AnthropicMessage {
+                        role: "user".to_string(),
+                        content: blocks,
+                    });
+                }
             }
             Role::Assistant => {
                 let mut blocks = map_regular_content(&message.content)?;
@@ -50,15 +52,12 @@ pub(super) fn map_request(
                         });
                     }
                 }
-                if blocks.is_empty() {
-                    blocks.push(AnthropicContentBlock::Text {
-                        text: String::new(),
+                if !blocks.is_empty() {
+                    messages.push(AnthropicMessage {
+                        role: "assistant".to_string(),
+                        content: blocks,
                     });
                 }
-                messages.push(AnthropicMessage {
-                    role: "assistant".to_string(),
-                    content: blocks,
-                });
             }
             Role::Tool => {
                 let tool_use_id = message
@@ -69,11 +68,13 @@ pub(super) fn map_request(
                         ProviderError::internal("tool_call_id is required for tool messages")
                     })?;
                 let result_text = extract_text_from_content(&message.content);
+                let content = (!result_text.is_empty())
+                    .then_some(vec![AnthropicContentBlock::Text { text: result_text }]);
                 messages.push(AnthropicMessage {
                     role: "user".to_string(),
                     content: vec![AnthropicContentBlock::ToolResult {
                         tool_use_id,
-                        content: vec![AnthropicContentBlock::Text { text: result_text }],
+                        content,
                         is_error: None,
                     }],
                 });
@@ -239,18 +240,20 @@ pub(super) fn map_stream_event(event: StreamEvent, state: &mut StreamState) -> V
                 });
             }
             StreamContentDelta::InputJsonDelta { partial_json } => {
-                if let Some(ActiveBlock::ToolUse {
-                    id,
-                    name,
-                    arguments,
-                }) = state.blocks.get_mut(&index)
-                {
-                    arguments.push_str(&partial_json);
-                    out.push(UnifiedEvent::ToolCallDelta {
-                        id: id.clone(),
-                        name: name.clone(),
-                        arguments_delta: partial_json,
-                    });
+                if !partial_json.is_empty() {
+                    if let Some(ActiveBlock::ToolUse {
+                        id,
+                        name,
+                        arguments,
+                    }) = state.blocks.get_mut(&index)
+                    {
+                        arguments.push_str(&partial_json);
+                        out.push(UnifiedEvent::ToolCallDelta {
+                            id: id.clone(),
+                            name: name.clone(),
+                            arguments_delta: partial_json,
+                        });
+                    }
                 }
             }
             StreamContentDelta::Unknown => {}
@@ -302,13 +305,20 @@ pub(super) fn map_stream_event(event: StreamEvent, state: &mut StreamState) -> V
 
 fn map_regular_content(content: &Content) -> Result<Vec<AnthropicContentBlock>, ProviderError> {
     match content {
-        Content::Text(text) => Ok(vec![AnthropicContentBlock::Text { text: text.clone() }]),
+        Content::Text(text) => {
+            if text.is_empty() {
+                return Ok(Vec::new());
+            }
+            Ok(vec![AnthropicContentBlock::Text { text: text.clone() }])
+        }
         Content::Parts(parts) => {
             let mut blocks = Vec::new();
             for part in parts {
                 match part {
                     ContentPart::Text { text } => {
-                        blocks.push(AnthropicContentBlock::Text { text: text.clone() });
+                        if !text.is_empty() {
+                            blocks.push(AnthropicContentBlock::Text { text: text.clone() });
+                        }
                     }
                     ContentPart::Image { image_url } => {
                         blocks.push(AnthropicContentBlock::Image {
@@ -331,7 +341,7 @@ fn map_regular_content(content: &Content) -> Result<Vec<AnthropicContentBlock>, 
 
 fn map_thinking(
     thinking: Option<&crate::openai_types::ThinkingConfig>,
-    _reasoning_effort: Option<&str>,
+    reasoning_effort: Option<&str>,
 ) -> Option<AnthropicThinking> {
     if let Some(config) = thinking {
         return match config.kind {
@@ -341,6 +351,10 @@ fn map_thinking(
             crate::openai_types::ThinkingType::Adaptive => Some(AnthropicThinking::Adaptive),
             crate::openai_types::ThinkingType::Disabled => Some(AnthropicThinking::Disabled),
         };
+    }
+
+    if reasoning_effort.is_some() {
+        return Some(AnthropicThinking::Adaptive);
     }
 
     None

--- a/src/llm_provider/anthropic_messages/mod.rs
+++ b/src/llm_provider/anthropic_messages/mod.rs
@@ -518,7 +518,7 @@ mod tests {
     }
 
     #[test]
-    fn map_request_uses_adaptive_thinking_from_reasoning_effort() {
+    fn map_request_disables_thinking_for_haiku_models() {
         let request = ChatCompletionRequest {
             model: "alias".to_string(),
             messages: vec![Message {
@@ -559,6 +559,108 @@ mod tests {
 
         let mapped = map_request(request, "claude-haiku-4-5".to_string(), DEFAULT_MAX_TOKENS)
             .expect("request should map");
+
+        assert!(mapped.thinking.is_none());
+    }
+
+    #[test]
+    fn map_request_disables_thinking_for_prefixed_haiku_models() {
+        let request = ChatCompletionRequest {
+            model: "alias".to_string(),
+            messages: vec![Message {
+                role: Role::User,
+                content: Content::Text("hello".to_string()),
+                reasoning_content: None,
+                tool_call_id: None,
+                tool_calls: None,
+            }],
+            n: None,
+            temperature: None,
+            top_p: None,
+            presence_penalty: None,
+            frequency_penalty: None,
+            logprobs: None,
+            top_logprobs: None,
+            modalities: None,
+            audio: None,
+            max_completion_tokens: None,
+            stop: None,
+            response_format: None,
+            thinking: Some(crate::openai_types::ThinkingConfig {
+                kind: crate::openai_types::ThinkingType::Enabled,
+            }),
+            reasoning_effort: Some("high".to_string()),
+            chat_template_kwargs: None,
+            prediction: None,
+            verbosity: None,
+            tools: None,
+            tool_choice: None,
+            allowed_tools: None,
+            parallel_tool_calls: None,
+            service_tier: None,
+            seed: None,
+            stream: None,
+            stream_options: None,
+            metadata: None,
+            agent_context: None,
+        };
+
+        let mapped = map_request(
+            request,
+            "anthropic.claude-haiku-4-5".to_string(),
+            DEFAULT_MAX_TOKENS,
+        )
+        .expect("request should map");
+
+        assert!(mapped.thinking.is_none());
+    }
+
+    #[test]
+    fn map_request_uses_adaptive_thinking_from_reasoning_effort_for_non_haiku_models() {
+        let request = ChatCompletionRequest {
+            model: "alias".to_string(),
+            messages: vec![Message {
+                role: Role::User,
+                content: Content::Text("hello".to_string()),
+                reasoning_content: None,
+                tool_call_id: None,
+                tool_calls: None,
+            }],
+            n: None,
+            temperature: None,
+            top_p: None,
+            presence_penalty: None,
+            frequency_penalty: None,
+            logprobs: None,
+            top_logprobs: None,
+            modalities: None,
+            audio: None,
+            max_completion_tokens: None,
+            stop: None,
+            response_format: None,
+            thinking: None,
+            reasoning_effort: Some("high".to_string()),
+            chat_template_kwargs: None,
+            prediction: None,
+            verbosity: None,
+            tools: None,
+            tool_choice: None,
+            allowed_tools: None,
+            parallel_tool_calls: None,
+            service_tier: None,
+            seed: None,
+            stream: None,
+            stream_options: None,
+            metadata: None,
+            agent_context: None,
+        };
+
+        let mapped = map_request(
+            request,
+            "global.anthropic.claude-sonnet-4-6".to_string(),
+            DEFAULT_MAX_TOKENS,
+        )
+        .expect("request should map");
 
         assert!(matches!(mapped.thinking, Some(AnthropicThinking::Adaptive)));
     }

--- a/src/llm_provider/anthropic_messages/mod.rs
+++ b/src/llm_provider/anthropic_messages/mod.rs
@@ -171,7 +171,7 @@ impl<M> Provider<M> for AnthropicMessagesProvider {
                 }
             }
 
-            if state.started {
+            if state.started && !state.completed {
                 let stop_reason = state
                     .stop_reason
                     .clone()
@@ -612,5 +612,102 @@ mod tests {
             &events[0],
             UnifiedEvent::ToolCallDone { arguments, .. } if arguments == "{}"
         ));
+    }
+
+    #[test]
+    fn map_request_generates_unique_fallback_tool_call_ids() {
+        let request = ChatCompletionRequest {
+            model: "alias".to_string(),
+            messages: vec![Message {
+                role: Role::Assistant,
+                content: Content::Text(String::new()),
+                reasoning_content: None,
+                tool_call_id: None,
+                tool_calls: Some(vec![
+                    crate::openai_types::ToolCall {
+                        id: None,
+                        r#type: Some("function".to_string()),
+                        function: crate::openai_types::ToolCallFunction {
+                            name: "lookup".to_string(),
+                            arguments: "{\"q\":\"x\"}".to_string(),
+                            description: None,
+                        },
+                    },
+                    crate::openai_types::ToolCall {
+                        id: None,
+                        r#type: Some("function".to_string()),
+                        function: crate::openai_types::ToolCallFunction {
+                            name: "lookup".to_string(),
+                            arguments: "{\"q\":\"y\"}".to_string(),
+                            description: None,
+                        },
+                    },
+                ]),
+            }],
+            n: None,
+            temperature: None,
+            top_p: None,
+            presence_penalty: None,
+            frequency_penalty: None,
+            logprobs: None,
+            top_logprobs: None,
+            modalities: None,
+            audio: None,
+            max_completion_tokens: None,
+            stop: None,
+            response_format: None,
+            thinking: None,
+            reasoning_effort: None,
+            chat_template_kwargs: None,
+            prediction: None,
+            verbosity: None,
+            tools: None,
+            tool_choice: None,
+            allowed_tools: None,
+            parallel_tool_calls: None,
+            service_tier: None,
+            seed: None,
+            stream: None,
+            stream_options: None,
+            metadata: None,
+            agent_context: None,
+        };
+
+        let mapped = map_request(request, "claude-sonnet-5".to_string(), DEFAULT_MAX_TOKENS)
+            .expect("request should map");
+
+        let AnthropicContentBlock::ToolUse { id: first_id, .. } = &mapped.messages[0].content[0]
+        else {
+            panic!("expected first tool use block");
+        };
+        let AnthropicContentBlock::ToolUse { id: second_id, .. } = &mapped.messages[0].content[1]
+        else {
+            panic!("expected second tool use block");
+        };
+
+        assert_ne!(first_id, second_id);
+    }
+
+    #[test]
+    fn map_stream_event_ignores_duplicate_message_stop() {
+        let mut state = StreamState::default();
+
+        let events = map_stream_event(
+            StreamEvent::MessageStart {
+                message: StreamMessage {
+                    id: "msg_1".to_string(),
+                    model: "claude-haiku-4-5".to_string(),
+                },
+            },
+            &mut state,
+        );
+        assert!(!events.is_empty());
+
+        let first_stop_events = map_stream_event(StreamEvent::MessageStop, &mut state);
+        assert_eq!(first_stop_events.len(), 2);
+        assert!(state.completed);
+
+        let second_stop_events = map_stream_event(StreamEvent::MessageStop, &mut state);
+        assert!(second_stop_events.is_empty());
     }
 }

--- a/src/llm_provider/anthropic_messages/mod.rs
+++ b/src/llm_provider/anthropic_messages/mod.rs
@@ -1,0 +1,455 @@
+use std::collections::HashMap;
+use std::pin::Pin;
+
+use async_stream::try_stream;
+use async_trait::async_trait;
+use futures_core::Stream;
+use futures_util::StreamExt;
+
+use crate::llm_provider::{Provider, ProviderError, UnifiedEvent, UnifiedResponse};
+use crate::openai_http_mapping::validate_openai_request;
+use crate::openai_types::ChatCompletionRequest;
+use crate::serve_config::ConfigError;
+
+use self::client::{Backend, BedrockClient, DirectClient, map_client_error, parse_auth_style};
+use self::mapper::{map_request, map_response, map_stop_reason_string, map_stream_event};
+use self::types::{
+    AnthropicRequest, BedrockRequest, DEFAULT_ANTHROPIC_VERSION, DEFAULT_BEDROCK_ANTHROPIC_VERSION,
+    DEFAULT_MAX_TOKENS, StreamState,
+};
+
+mod client;
+mod mapper;
+mod types;
+
+#[derive(Clone)]
+pub struct AnthropicMessagesProvider {
+    backend: Backend,
+    upstream_model: String,
+    anthropic_version: String,
+    default_max_tokens: i32,
+}
+
+impl AnthropicMessagesProvider {
+    fn new(
+        backend: Backend,
+        upstream_model: String,
+        anthropic_version: String,
+        default_max_tokens: i32,
+    ) -> Self {
+        Self {
+            backend,
+            upstream_model,
+            anthropic_version,
+            default_max_tokens,
+        }
+    }
+}
+
+#[async_trait]
+impl<M> Provider<M> for AnthropicMessagesProvider {
+    fn model_id(&self) -> &str {
+        "anthropic-messages"
+    }
+
+    async fn complete(
+        &self,
+        request: ChatCompletionRequest,
+        _metadata: &M,
+    ) -> Result<UnifiedResponse, ProviderError> {
+        validate_openai_request(&request).map_err(ProviderError::internal)?;
+        let mapped = map_request(
+            request,
+            self.upstream_model.clone(),
+            self.default_max_tokens,
+        )?;
+        let response = match &self.backend {
+            Backend::Direct(client) => {
+                let payload = AnthropicRequest {
+                    model: mapped.model,
+                    max_tokens: mapped.max_tokens,
+                    messages: mapped.messages,
+                    system: mapped.system,
+                    temperature: mapped.temperature,
+                    top_p: mapped.top_p,
+                    stop_sequences: mapped.stop_sequences,
+                    stream: Some(false),
+                    tools: mapped.tools,
+                    tool_choice: mapped.tool_choice,
+                    thinking: mapped.thinking,
+                };
+                client
+                    .send_complete(payload, &self.anthropic_version)
+                    .await
+                    .map_err(map_client_error)?
+            }
+            Backend::Bedrock(client) => {
+                let payload = BedrockRequest {
+                    anthropic_version: self.anthropic_version.clone(),
+                    max_tokens: mapped.max_tokens,
+                    messages: mapped.messages,
+                    system: mapped.system,
+                    temperature: mapped.temperature,
+                    top_p: mapped.top_p,
+                    stop_sequences: mapped.stop_sequences,
+                    tools: mapped.tools,
+                    tool_choice: mapped.tool_choice,
+                    thinking: mapped.thinking,
+                };
+                client
+                    .send_complete(payload)
+                    .await
+                    .map_err(map_client_error)?
+            }
+        };
+
+        Ok(map_response(response))
+    }
+
+    async fn stream<'a>(
+        &'a self,
+        request: ChatCompletionRequest,
+        _metadata: &M,
+    ) -> Result<
+        Pin<Box<dyn Stream<Item = Result<UnifiedEvent, ProviderError>> + Send + 'a>>,
+        ProviderError,
+    > {
+        validate_openai_request(&request).map_err(ProviderError::internal)?;
+        let mapped = map_request(
+            request,
+            self.upstream_model.clone(),
+            self.default_max_tokens,
+        )?;
+
+        let stream = match &self.backend {
+            Backend::Direct(client) => {
+                let payload = AnthropicRequest {
+                    model: mapped.model,
+                    max_tokens: mapped.max_tokens,
+                    messages: mapped.messages,
+                    system: mapped.system,
+                    temperature: mapped.temperature,
+                    top_p: mapped.top_p,
+                    stop_sequences: mapped.stop_sequences,
+                    stream: Some(true),
+                    tools: mapped.tools,
+                    tool_choice: mapped.tool_choice,
+                    thinking: mapped.thinking,
+                };
+                client
+                    .send_stream(payload, &self.anthropic_version)
+                    .await
+                    .map_err(map_client_error)?
+            }
+            Backend::Bedrock(client) => {
+                let payload = BedrockRequest {
+                    anthropic_version: self.anthropic_version.clone(),
+                    max_tokens: mapped.max_tokens,
+                    messages: mapped.messages,
+                    system: mapped.system,
+                    temperature: mapped.temperature,
+                    top_p: mapped.top_p,
+                    stop_sequences: mapped.stop_sequences,
+                    tools: mapped.tools,
+                    tool_choice: mapped.tool_choice,
+                    thinking: mapped.thinking,
+                };
+                client
+                    .send_stream(payload)
+                    .await
+                    .map_err(map_client_error)?
+            }
+        };
+
+        let output = try_stream! {
+            futures_util::pin_mut!(stream);
+            let mut state = StreamState::default();
+            while let Some(item) = stream.next().await {
+                let event = item?;
+                for mapped_event in map_stream_event(event, &mut state) {
+                    yield mapped_event;
+                }
+            }
+
+            if state.started {
+                let stop_reason = state
+                    .stop_reason
+                    .clone()
+                    .unwrap_or_else(|| "end_turn".to_string());
+                yield UnifiedEvent::MessageStop {
+                    id: state.response_id,
+                    stop_reason: Some(map_stop_reason_string(&stop_reason).to_string()),
+                };
+                yield UnifiedEvent::Completed {
+                    finish_reason: Some(map_stop_reason_string(&stop_reason).to_string()),
+                };
+            }
+        };
+
+        Ok(Box::pin(output))
+    }
+}
+
+pub fn build_anthropic_messages_provider(
+    params: &HashMap<String, String>,
+) -> Result<AnthropicMessagesProvider, ConfigError> {
+    let api_key = params
+        .get("api_key")
+        .cloned()
+        .ok_or_else(|| ConfigError::InvalidProvider("api_key is required".to_string()))?;
+    let base_url = params
+        .get("base_url")
+        .cloned()
+        .ok_or_else(|| ConfigError::InvalidProvider("base_url is required".to_string()))?;
+    let upstream_model = params
+        .get("model")
+        .cloned()
+        .ok_or_else(|| ConfigError::InvalidProvider("model is required".to_string()))?;
+    let anthropic_version = params
+        .get("anthropic_version")
+        .cloned()
+        .unwrap_or_else(|| DEFAULT_ANTHROPIC_VERSION.to_string());
+    let auth_style = parse_auth_style(params.get("auth_style"))?;
+
+    Ok(AnthropicMessagesProvider::new(
+        Backend::Direct(DirectClient {
+            client: reqwest::Client::new(),
+            base_url,
+            auth_style,
+            api_key,
+        }),
+        upstream_model,
+        anthropic_version,
+        DEFAULT_MAX_TOKENS,
+    ))
+}
+
+pub fn build_bedrock_messages_provider(
+    params: &HashMap<String, String>,
+) -> Result<AnthropicMessagesProvider, ConfigError> {
+    let bedrock_model = params
+        .get("model")
+        .cloned()
+        .ok_or_else(|| ConfigError::InvalidProvider("model is required".to_string()))?;
+    let aws_region = params
+        .get("aws_region")
+        .cloned()
+        .ok_or_else(|| ConfigError::InvalidProvider("aws_region is required".to_string()))?;
+    let aws_bearer_token = params
+        .get("aws_bearer_token")
+        .map(|token| token.trim().to_string())
+        .filter(|token| !token.is_empty())
+        .ok_or_else(|| ConfigError::InvalidProvider("aws_bearer_token is required".to_string()))?;
+    let anthropic_version = params
+        .get("anthropic_version")
+        .cloned()
+        .unwrap_or_else(|| DEFAULT_BEDROCK_ANTHROPIC_VERSION.to_string());
+    let max_tokens = params
+        .get("max_tokens")
+        .and_then(|raw| raw.parse::<i32>().ok())
+        .unwrap_or(DEFAULT_MAX_TOKENS);
+
+    Ok(AnthropicMessagesProvider::new(
+        Backend::Bedrock(BedrockClient {
+            model_id: bedrock_model.clone(),
+            aws_region,
+            aws_bearer_token,
+        }),
+        bedrock_model,
+        anthropic_version,
+        max_tokens,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+    use crate::llm_provider::anthropic_messages::types::AnthropicContentBlock;
+    use crate::openai_types::{
+        Content, FunctionDefinition, Message, Role, ToolChoice, ToolDefinition,
+    };
+
+    #[test]
+    fn build_anthropic_messages_provider_accepts_x_api_key_auth_style() {
+        let mut params = HashMap::new();
+        params.insert("api_key".to_string(), "sk-ant-test".to_string());
+        params.insert(
+            "base_url".to_string(),
+            "https://api.anthropic.com/v1".to_string(),
+        );
+        params.insert("model".to_string(), "claude-sonnet-5".to_string());
+
+        let provider = build_anthropic_messages_provider(&params)
+            .expect("anthropic messages provider should build");
+
+        assert_eq!(provider.upstream_model, "claude-sonnet-5");
+    }
+
+    #[test]
+    fn build_anthropic_messages_provider_accepts_bearer_auth_style() {
+        let mut params = HashMap::new();
+        params.insert("api_key".to_string(), "token".to_string());
+        params.insert(
+            "base_url".to_string(),
+            "https://proxy.example.com/v1".to_string(),
+        );
+        params.insert("model".to_string(), "claude-sonnet-5".to_string());
+        params.insert("auth_style".to_string(), "bearer".to_string());
+
+        let provider = build_anthropic_messages_provider(&params)
+            .expect("anthropic messages provider should build");
+
+        assert_eq!(provider.anthropic_version, DEFAULT_ANTHROPIC_VERSION);
+    }
+
+    #[test]
+    fn build_bedrock_messages_provider_accepts_required_params() {
+        let mut params = HashMap::new();
+        params.insert(
+            "model".to_string(),
+            "global.anthropic.claude-sonnet-4-6".to_string(),
+        );
+        params.insert("aws_region".to_string(), "ap-northeast-1".to_string());
+        params.insert("aws_bearer_token".to_string(), "token".to_string());
+
+        let provider = build_bedrock_messages_provider(&params)
+            .expect("bedrock messages provider should build");
+
+        assert_eq!(provider.default_max_tokens, DEFAULT_MAX_TOKENS);
+    }
+
+    #[test]
+    fn map_request_maps_tool_messages_to_tool_result_blocks() {
+        let request = ChatCompletionRequest {
+            model: "alias".to_string(),
+            messages: vec![
+                Message {
+                    role: Role::Assistant,
+                    content: Content::Text(String::new()),
+                    reasoning_content: None,
+                    tool_call_id: None,
+                    tool_calls: Some(vec![crate::openai_types::ToolCall {
+                        id: Some("call_1".to_string()),
+                        r#type: Some("function".to_string()),
+                        function: crate::openai_types::ToolCallFunction {
+                            name: "lookup".to_string(),
+                            arguments: "{\"q\":\"x\"}".to_string(),
+                            description: None,
+                        },
+                    }]),
+                },
+                Message {
+                    role: Role::Tool,
+                    content: Content::Text("ok".to_string()),
+                    reasoning_content: None,
+                    tool_call_id: Some("call_1".to_string()),
+                    tool_calls: None,
+                },
+            ],
+            n: None,
+            temperature: None,
+            top_p: None,
+            presence_penalty: None,
+            frequency_penalty: None,
+            logprobs: None,
+            top_logprobs: None,
+            modalities: None,
+            audio: None,
+            max_completion_tokens: None,
+            stop: None,
+            response_format: None,
+            thinking: None,
+            reasoning_effort: None,
+            chat_template_kwargs: None,
+            prediction: None,
+            verbosity: None,
+            tools: Some(vec![ToolDefinition {
+                r#type: "function".to_string(),
+                function: FunctionDefinition {
+                    name: "lookup".to_string(),
+                    description: None,
+                    strict: None,
+                    parameters: json!({"type": "object"}),
+                },
+            }]),
+            tool_choice: Some(ToolChoice::Name("auto".to_string())),
+            allowed_tools: None,
+            parallel_tool_calls: Some(false),
+            service_tier: None,
+            seed: None,
+            stream: None,
+            stream_options: None,
+            metadata: None,
+            agent_context: None,
+        };
+
+        let mapped = map_request(request, "claude-sonnet-5".to_string(), DEFAULT_MAX_TOKENS)
+            .expect("request should map");
+
+        assert_eq!(mapped.messages.len(), 2);
+        assert!(matches!(
+            mapped.messages[1].content[0],
+            AnthropicContentBlock::ToolResult { .. }
+        ));
+    }
+
+    #[test]
+    fn map_request_does_not_enable_thinking_from_reasoning_effort() {
+        let request = ChatCompletionRequest {
+            model: "alias".to_string(),
+            messages: vec![Message {
+                role: Role::User,
+                content: Content::Text("hello".to_string()),
+                reasoning_content: None,
+                tool_call_id: None,
+                tool_calls: None,
+            }],
+            n: None,
+            temperature: None,
+            top_p: None,
+            presence_penalty: None,
+            frequency_penalty: None,
+            logprobs: None,
+            top_logprobs: None,
+            modalities: None,
+            audio: None,
+            max_completion_tokens: None,
+            stop: None,
+            response_format: None,
+            thinking: None,
+            reasoning_effort: Some("high".to_string()),
+            chat_template_kwargs: None,
+            prediction: None,
+            verbosity: None,
+            tools: None,
+            tool_choice: None,
+            allowed_tools: None,
+            parallel_tool_calls: None,
+            service_tier: None,
+            seed: None,
+            stream: None,
+            stream_options: None,
+            metadata: None,
+            agent_context: None,
+        };
+
+        let mapped = map_request(request, "claude-haiku-4-5".to_string(), DEFAULT_MAX_TOKENS)
+            .expect("request should map");
+
+        assert!(mapped.thinking.is_none());
+    }
+
+    #[test]
+    fn parse_auth_style_rejects_unknown() {
+        let err = super::client::parse_auth_style(Some(&"unknown".to_string()))
+            .err()
+            .expect("unknown auth style should error");
+
+        assert_eq!(
+            err.to_string(),
+            "invalid provider: unknown auth_style: unknown"
+        );
+    }
+}

--- a/src/llm_provider/anthropic_messages/mod.rs
+++ b/src/llm_provider/anthropic_messages/mod.rs
@@ -5,6 +5,7 @@ use async_stream::try_stream;
 use async_trait::async_trait;
 use futures_core::Stream;
 use futures_util::StreamExt;
+use log::warn;
 
 use crate::llm_provider::{Provider, ProviderError, UnifiedEvent, UnifiedResponse};
 use crate::openai_http_mapping::validate_openai_request;
@@ -169,6 +170,13 @@ impl<M> Provider<M> for AnthropicMessagesProvider {
                 for mapped_event in map_stream_event(event, &mut state) {
                     yield mapped_event;
                 }
+            }
+
+            if !state.usage_received {
+                warn!(
+                    "anthropic messages upstream stream missing usage; model={} request_id={}",
+                    state.model, state.response_id
+                );
             }
 
             if state.started && !state.completed {
@@ -709,5 +717,29 @@ mod tests {
 
         let second_stop_events = map_stream_event(StreamEvent::MessageStop, &mut state);
         assert!(second_stop_events.is_empty());
+    }
+
+    #[test]
+    fn map_stream_event_tracks_received_usage() {
+        let mut state = StreamState::default();
+
+        map_stream_event(
+            StreamEvent::MessageDelta {
+                delta: None,
+                usage: Some(crate::model_api_provider::MessagesUsage {
+                    input_tokens: Some(10),
+                    output_tokens: Some(2),
+                    cache_creation_input_tokens: None,
+                    cache_read_input_tokens: None,
+                    cache_creation: None,
+                    inference_geo: None,
+                    service_tier: None,
+                    server_tool_use: None,
+                }),
+            },
+            &mut state,
+        );
+
+        assert!(state.usage_received);
     }
 }

--- a/src/llm_provider/anthropic_messages/mod.rs
+++ b/src/llm_provider/anthropic_messages/mod.rs
@@ -266,7 +266,12 @@ mod tests {
     use serde_json::json;
 
     use super::*;
-    use crate::llm_provider::anthropic_messages::types::AnthropicContentBlock;
+    use crate::llm_provider::anthropic_messages::types::{
+        AnthropicContentBlock, AnthropicThinking,
+    };
+    use crate::llm_provider::anthropic_messages::types::{
+        StreamContentBlock, StreamContentDelta, StreamEvent, StreamMessage,
+    };
     use crate::openai_types::{
         Content, FunctionDefinition, Message, Role, ToolChoice, ToolDefinition,
     };
@@ -396,7 +401,116 @@ mod tests {
     }
 
     #[test]
-    fn map_request_does_not_enable_thinking_from_reasoning_effort() {
+    fn map_request_skips_empty_assistant_message_without_tool_calls() {
+        let request = ChatCompletionRequest {
+            model: "alias".to_string(),
+            messages: vec![
+                Message {
+                    role: Role::User,
+                    content: Content::Text("hi".to_string()),
+                    reasoning_content: None,
+                    tool_call_id: None,
+                    tool_calls: None,
+                },
+                Message {
+                    role: Role::Assistant,
+                    content: Content::Text(String::new()),
+                    reasoning_content: None,
+                    tool_call_id: None,
+                    tool_calls: None,
+                },
+            ],
+            n: None,
+            temperature: None,
+            top_p: None,
+            presence_penalty: None,
+            frequency_penalty: None,
+            logprobs: None,
+            top_logprobs: None,
+            modalities: None,
+            audio: None,
+            max_completion_tokens: None,
+            stop: None,
+            response_format: None,
+            thinking: None,
+            reasoning_effort: None,
+            chat_template_kwargs: None,
+            prediction: None,
+            verbosity: None,
+            tools: None,
+            tool_choice: None,
+            allowed_tools: None,
+            parallel_tool_calls: None,
+            service_tier: None,
+            seed: None,
+            stream: None,
+            stream_options: None,
+            metadata: None,
+            agent_context: None,
+        };
+
+        let mapped = map_request(request, "claude-sonnet-5".to_string(), DEFAULT_MAX_TOKENS)
+            .expect("request should map");
+
+        assert_eq!(mapped.messages.len(), 1);
+        assert!(matches!(
+            mapped.messages[0].content[0],
+            AnthropicContentBlock::Text { .. }
+        ));
+    }
+
+    #[test]
+    fn map_request_omits_empty_tool_result_text_content() {
+        let request = ChatCompletionRequest {
+            model: "alias".to_string(),
+            messages: vec![Message {
+                role: Role::Tool,
+                content: Content::Text(String::new()),
+                reasoning_content: None,
+                tool_call_id: Some("call_1".to_string()),
+                tool_calls: None,
+            }],
+            n: None,
+            temperature: None,
+            top_p: None,
+            presence_penalty: None,
+            frequency_penalty: None,
+            logprobs: None,
+            top_logprobs: None,
+            modalities: None,
+            audio: None,
+            max_completion_tokens: None,
+            stop: None,
+            response_format: None,
+            thinking: None,
+            reasoning_effort: None,
+            chat_template_kwargs: None,
+            prediction: None,
+            verbosity: None,
+            tools: None,
+            tool_choice: None,
+            allowed_tools: None,
+            parallel_tool_calls: None,
+            service_tier: None,
+            seed: None,
+            stream: None,
+            stream_options: None,
+            metadata: None,
+            agent_context: None,
+        };
+
+        let mapped = map_request(request, "claude-sonnet-5".to_string(), DEFAULT_MAX_TOKENS)
+            .expect("request should map");
+
+        assert_eq!(mapped.messages.len(), 1);
+        assert!(matches!(
+            &mapped.messages[0].content[0],
+            AnthropicContentBlock::ToolResult { content: None, .. }
+        ));
+    }
+
+    #[test]
+    fn map_request_uses_adaptive_thinking_from_reasoning_effort() {
         let request = ChatCompletionRequest {
             model: "alias".to_string(),
             messages: vec![Message {
@@ -438,7 +552,7 @@ mod tests {
         let mapped = map_request(request, "claude-haiku-4-5".to_string(), DEFAULT_MAX_TOKENS)
             .expect("request should map");
 
-        assert!(mapped.thinking.is_none());
+        assert!(matches!(mapped.thinking, Some(AnthropicThinking::Adaptive)));
     }
 
     #[test]
@@ -451,5 +565,52 @@ mod tests {
             err.to_string(),
             "invalid provider: unknown auth_style: unknown"
         );
+    }
+
+    #[test]
+    fn map_stream_event_ignores_empty_input_json_delta() {
+        let mut state = StreamState::default();
+
+        let events = map_stream_event(
+            StreamEvent::MessageStart {
+                message: StreamMessage {
+                    id: "msg_1".to_string(),
+                    model: "claude-haiku-4-5".to_string(),
+                },
+            },
+            &mut state,
+        );
+        assert!(!events.is_empty());
+
+        let events = map_stream_event(
+            StreamEvent::ContentBlockStart {
+                index: 0,
+                content_block: StreamContentBlock::ToolUse {
+                    id: "toolu_1".to_string(),
+                    name: "TaskList".to_string(),
+                    input: json!({}),
+                },
+            },
+            &mut state,
+        );
+        assert!(events.is_empty());
+
+        let events = map_stream_event(
+            StreamEvent::ContentBlockDelta {
+                index: 0,
+                delta: StreamContentDelta::InputJsonDelta {
+                    partial_json: String::new(),
+                },
+            },
+            &mut state,
+        );
+        assert!(events.is_empty());
+
+        let events = map_stream_event(StreamEvent::ContentBlockStop { index: 0 }, &mut state);
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            &events[0],
+            UnifiedEvent::ToolCallDone { arguments, .. } if arguments == "{}"
+        ));
     }
 }

--- a/src/llm_provider/anthropic_messages/types.rs
+++ b/src/llm_provider/anthropic_messages/types.rs
@@ -242,6 +242,7 @@ pub(super) struct StreamState {
     pub model: String,
     pub created_at: String,
     pub started: bool,
+    pub completed: bool,
     pub stop_reason: Option<String>,
     pub blocks: HashMap<usize, ActiveBlock>,
 }

--- a/src/llm_provider/anthropic_messages/types.rs
+++ b/src/llm_provider/anthropic_messages/types.rs
@@ -75,7 +75,8 @@ pub(super) enum AnthropicContentBlock {
     },
     ToolResult {
         tool_use_id: String,
-        content: Vec<AnthropicContentBlock>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        content: Option<Vec<AnthropicContentBlock>>,
         #[serde(skip_serializing_if = "Option::is_none")]
         is_error: Option<bool>,
     },

--- a/src/llm_provider/anthropic_messages/types.rs
+++ b/src/llm_provider/anthropic_messages/types.rs
@@ -1,0 +1,268 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::model_api_provider::MessagesUsage;
+
+pub(super) const DEFAULT_ANTHROPIC_VERSION: &str = "2023-06-01";
+pub(super) const DEFAULT_BEDROCK_ANTHROPIC_VERSION: &str = "bedrock-2023-05-31";
+pub(super) const DEFAULT_MAX_TOKENS: i32 = 4096;
+
+#[derive(Serialize)]
+pub(super) struct AnthropicRequest {
+    pub model: String,
+    pub max_tokens: i32,
+    pub messages: Vec<AnthropicMessage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub system: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub top_p: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop_sequences: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stream: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Vec<AnthropicTool>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_choice: Option<AnthropicToolChoice>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thinking: Option<AnthropicThinking>,
+}
+
+#[derive(Serialize)]
+pub(super) struct BedrockRequest {
+    pub anthropic_version: String,
+    pub max_tokens: i32,
+    pub messages: Vec<AnthropicMessage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub system: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub top_p: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop_sequences: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Vec<AnthropicTool>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_choice: Option<AnthropicToolChoice>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thinking: Option<AnthropicThinking>,
+}
+
+#[derive(Serialize)]
+pub(super) struct AnthropicMessage {
+    pub role: String,
+    pub content: Vec<AnthropicContentBlock>,
+}
+
+#[derive(Serialize, Clone)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub(super) enum AnthropicContentBlock {
+    Text {
+        text: String,
+    },
+    Image {
+        source: AnthropicImageSource,
+    },
+    ToolUse {
+        id: String,
+        name: String,
+        input: Value,
+    },
+    ToolResult {
+        tool_use_id: String,
+        content: Vec<AnthropicContentBlock>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        is_error: Option<bool>,
+    },
+}
+
+#[derive(Serialize, Clone)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub(super) enum AnthropicImageSource {
+    Url { url: String },
+}
+
+#[derive(Serialize)]
+pub(super) struct AnthropicTool {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub input_schema: Value,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub(super) enum AnthropicToolChoice {
+    Auto {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        disable_parallel_tool_use: Option<bool>,
+    },
+    Any {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        disable_parallel_tool_use: Option<bool>,
+    },
+    Tool {
+        name: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        disable_parallel_tool_use: Option<bool>,
+    },
+    None,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub(super) enum AnthropicThinking {
+    Adaptive,
+    Enabled { budget_tokens: i32 },
+    Disabled,
+}
+
+#[derive(Deserialize)]
+pub(super) struct AnthropicResponse {
+    pub id: String,
+    pub model: String,
+    pub content: Vec<AnthropicResponseContentBlock>,
+    #[serde(default)]
+    pub stop_reason: Option<String>,
+    #[serde(default)]
+    pub usage: Option<MessagesUsage>,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub(super) enum AnthropicResponseContentBlock {
+    Text {
+        text: String,
+    },
+    Thinking {
+        thinking: String,
+    },
+    ToolUse {
+        id: String,
+        name: String,
+        input: Value,
+    },
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Deserialize)]
+pub(super) struct AnthropicErrorEnvelope {
+    pub error: AnthropicError,
+}
+
+#[derive(Deserialize)]
+pub(super) struct AnthropicError {
+    #[serde(default)]
+    pub r#type: Option<String>,
+    pub message: String,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub(super) enum StreamEvent {
+    MessageStart {
+        message: StreamMessage,
+    },
+    ContentBlockStart {
+        index: usize,
+        content_block: StreamContentBlock,
+    },
+    ContentBlockDelta {
+        index: usize,
+        delta: StreamContentDelta,
+    },
+    ContentBlockStop {
+        index: usize,
+    },
+    MessageDelta {
+        #[serde(default)]
+        delta: Option<StreamMessageDelta>,
+        #[serde(default)]
+        usage: Option<MessagesUsage>,
+    },
+    MessageStop,
+    Ping,
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Deserialize)]
+pub(super) struct StreamMessage {
+    pub id: String,
+    pub model: String,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub(super) enum StreamContentBlock {
+    Text {},
+    Thinking {},
+    ToolUse {
+        id: String,
+        name: String,
+        #[serde(default)]
+        input: Value,
+    },
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub(super) enum StreamContentDelta {
+    TextDelta {
+        text: String,
+    },
+    ThinkingDelta {
+        thinking: String,
+    },
+    InputJsonDelta {
+        partial_json: String,
+    },
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Deserialize)]
+pub(super) struct StreamMessageDelta {
+    #[serde(default)]
+    pub stop_reason: Option<String>,
+}
+
+#[derive(Default)]
+pub(super) struct StreamState {
+    pub response_id: String,
+    pub model: String,
+    pub created_at: String,
+    pub started: bool,
+    pub stop_reason: Option<String>,
+    pub blocks: HashMap<usize, ActiveBlock>,
+}
+
+pub(super) enum ActiveBlock {
+    ToolUse {
+        id: String,
+        name: String,
+        arguments: String,
+    },
+    Other,
+}
+
+pub(super) struct RequestParts {
+    pub model: String,
+    pub max_tokens: i32,
+    pub messages: Vec<AnthropicMessage>,
+    pub system: Option<String>,
+    pub temperature: Option<f32>,
+    pub top_p: Option<f32>,
+    pub stop_sequences: Option<Vec<String>>,
+    pub tools: Option<Vec<AnthropicTool>>,
+    pub tool_choice: Option<AnthropicToolChoice>,
+    pub thinking: Option<AnthropicThinking>,
+}

--- a/src/llm_provider/anthropic_messages/types.rs
+++ b/src/llm_provider/anthropic_messages/types.rs
@@ -243,6 +243,7 @@ pub(super) struct StreamState {
     pub created_at: String,
     pub started: bool,
     pub completed: bool,
+    pub usage_received: bool,
     pub stop_reason: Option<String>,
     pub blocks: HashMap<usize, ActiveBlock>,
 }

--- a/src/llm_provider/mod.rs
+++ b/src/llm_provider/mod.rs
@@ -1,3 +1,4 @@
+pub mod anthropic_messages;
 pub mod openai;
 pub mod openai_compatible;
 pub mod provider;

--- a/src/llm_provider/registry.rs
+++ b/src/llm_provider/registry.rs
@@ -8,6 +8,9 @@ use crate::llm_provider::Provider;
 use crate::llm_provider::ProviderError;
 use crate::llm_provider::UnifiedEvent;
 use crate::llm_provider::UnifiedResponse;
+use crate::llm_provider::anthropic_messages::{
+    build_anthropic_messages_provider, build_bedrock_messages_provider,
+};
 use crate::llm_provider::openai::build_openai_provider;
 use crate::llm_provider::openai_compatible::build_openai_compatible_provider;
 use crate::llm_provider::selection::SelectionError;
@@ -69,6 +72,8 @@ impl<M> ProviderRegistry<M> {
             let provider: Arc<dyn Provider<M>> = match item.provider_type.as_str() {
                 "openai" => Arc::new(build_openai_provider(&item.params)?),
                 "openai-compatible" => Arc::new(build_openai_compatible_provider(&item.params)?),
+                "anthropic-messages" => Arc::new(build_anthropic_messages_provider(&item.params)?),
+                "bedrock-messages" => Arc::new(build_bedrock_messages_provider(&item.params)?),
                 "tokenhub" => Arc::new(build_tokenhub_provider(&item.params)?),
                 "vllm_deepseek" => Arc::new(build_vllm_deepseek_provider(&item.params)?),
                 "vertexai" => Arc::new(build_vertexai_provider(&item.params)?),


### PR DESCRIPTION
## What
- add new LLM provider types: anthropic-messages and bedrock-messages
- implement Anthropic Messages provider with direct and Bedrock backends
- map OpenAI chat requests/responses/stream events to unified provider interfaces
- harden mapping for empty content blocks and tool-call JSON deltas
- map reasoning_effort fallback to Anthropic thinking adaptive

## Why
- enable Claude Messages-style models in the llm_provider path for agent loop and /v1/chat/completions
- align config style with existing messages and bedrock_messages conventions

## Validation
- cargo fmt
- cargo check
- cargo test (223 passed)