### PR TITLE
fix: gate anthropic sampling compatibility by request model

### DIFF
--- a/src/llm_provider/anthropic_messages/mapper.rs
+++ b/src/llm_provider/anthropic_messages/mapper.rs
@@ -16,7 +16,14 @@ pub(super) fn map_request(
     request: ChatCompletionRequest,
     upstream_model: String,
     default_max_tokens: i32,
+    sampling_compat: bool,
 ) -> Result<RequestParts, ProviderError> {
+    let (temperature, top_p) = map_sampling_params(
+        request.temperature,
+        request.top_p,
+        &request.model,
+        sampling_compat,
+    );
     let mut system_chunks = Vec::<String>::new();
     let mut messages = Vec::<AnthropicMessage>::new();
 
@@ -123,13 +130,49 @@ pub(super) fn map_request(
         max_tokens: request.max_completion_tokens.unwrap_or(default_max_tokens),
         messages,
         system: (!system_chunks.is_empty()).then(|| system_chunks.join("\n")),
-        temperature: request.temperature,
-        top_p: request.top_p,
+        temperature,
+        top_p,
         stop_sequences: request.stop,
         tools,
         tool_choice,
         thinking,
     })
+}
+
+fn map_sampling_params(
+    temperature: Option<f32>,
+    top_p: Option<f32>,
+    model: &str,
+    sampling_compat: bool,
+) -> (Option<f32>, Option<f32>) {
+    if !sampling_compat || !is_sampling_restricted_model(model) {
+        return (temperature, top_p);
+    }
+
+    (
+        filter_non_default_sampling_value(temperature),
+        filter_non_default_sampling_value(top_p),
+    )
+}
+
+fn filter_non_default_sampling_value(value: Option<f32>) -> Option<f32> {
+    match value {
+        Some(v) if (v - 1.0).abs() < f32::EPSILON => Some(v),
+        Some(_) => None,
+        None => None,
+    }
+}
+
+fn is_sampling_restricted_model(model: &str) -> bool {
+    matches!(
+        model.to_ascii_lowercase().as_str(),
+        "claude-sonnet-5"
+            | "claude-opus-5"
+            | "claude-opus-4-8"
+            | "claude-opus-4-7"
+            | "claude-fable-5"
+            | "claude-mythos-5"
+    )
 }
 
 pub(super) fn map_response(response: AnthropicResponse) -> UnifiedResponse {

--- a/src/llm_provider/anthropic_messages/mod.rs
+++ b/src/llm_provider/anthropic_messages/mod.rs
@@ -63,6 +63,7 @@ impl<M> Provider<M> for AnthropicMessagesProvider {
             request,
             self.upstream_model.clone(),
             self.default_max_tokens,
+            true,
         )?;
         let response = match &self.backend {
             Backend::Direct(client) => {
@@ -120,6 +121,7 @@ impl<M> Provider<M> for AnthropicMessagesProvider {
             request,
             self.upstream_model.clone(),
             self.default_max_tokens,
+            true,
         )?;
 
         let stream = match &self.backend {
@@ -284,6 +286,46 @@ mod tests {
         Content, FunctionDefinition, Message, Role, ToolChoice, ToolDefinition,
     };
 
+    fn basic_chat_request(temperature: Option<f32>, top_p: Option<f32>) -> ChatCompletionRequest {
+        ChatCompletionRequest {
+            model: "alias".to_string(),
+            messages: vec![Message {
+                role: Role::User,
+                content: Content::Text("hello".to_string()),
+                reasoning_content: None,
+                tool_call_id: None,
+                tool_calls: None,
+            }],
+            n: None,
+            temperature,
+            top_p,
+            presence_penalty: None,
+            frequency_penalty: None,
+            logprobs: None,
+            top_logprobs: None,
+            modalities: None,
+            audio: None,
+            max_completion_tokens: None,
+            stop: None,
+            response_format: None,
+            thinking: None,
+            reasoning_effort: None,
+            chat_template_kwargs: None,
+            prediction: None,
+            verbosity: None,
+            tools: None,
+            tool_choice: None,
+            allowed_tools: None,
+            parallel_tool_calls: None,
+            service_tier: None,
+            seed: None,
+            stream: None,
+            stream_options: None,
+            metadata: None,
+            agent_context: None,
+        }
+    }
+
     #[test]
     fn build_anthropic_messages_provider_accepts_x_api_key_auth_style() {
         let mut params = HashMap::new();
@@ -398,8 +440,13 @@ mod tests {
             agent_context: None,
         };
 
-        let mapped = map_request(request, "claude-sonnet-5".to_string(), DEFAULT_MAX_TOKENS)
-            .expect("request should map");
+        let mapped = map_request(
+            request,
+            "claude-sonnet-5".to_string(),
+            DEFAULT_MAX_TOKENS,
+            false,
+        )
+        .expect("request should map");
 
         assert_eq!(mapped.messages.len(), 2);
         assert!(matches!(
@@ -457,8 +504,13 @@ mod tests {
             agent_context: None,
         };
 
-        let mapped = map_request(request, "claude-sonnet-5".to_string(), DEFAULT_MAX_TOKENS)
-            .expect("request should map");
+        let mapped = map_request(
+            request,
+            "claude-sonnet-5".to_string(),
+            DEFAULT_MAX_TOKENS,
+            false,
+        )
+        .expect("request should map");
 
         assert_eq!(mapped.messages.len(), 1);
         assert!(matches!(
@@ -507,8 +559,13 @@ mod tests {
             agent_context: None,
         };
 
-        let mapped = map_request(request, "claude-sonnet-5".to_string(), DEFAULT_MAX_TOKENS)
-            .expect("request should map");
+        let mapped = map_request(
+            request,
+            "claude-sonnet-5".to_string(),
+            DEFAULT_MAX_TOKENS,
+            false,
+        )
+        .expect("request should map");
 
         assert_eq!(mapped.messages.len(), 1);
         assert!(matches!(
@@ -557,8 +614,13 @@ mod tests {
             agent_context: None,
         };
 
-        let mapped = map_request(request, "claude-haiku-4-5".to_string(), DEFAULT_MAX_TOKENS)
-            .expect("request should map");
+        let mapped = map_request(
+            request,
+            "claude-haiku-4-5".to_string(),
+            DEFAULT_MAX_TOKENS,
+            false,
+        )
+        .expect("request should map");
 
         assert!(mapped.thinking.is_none());
     }
@@ -609,6 +671,7 @@ mod tests {
             request,
             "anthropic.claude-haiku-4-5".to_string(),
             DEFAULT_MAX_TOKENS,
+            false,
         )
         .expect("request should map");
 
@@ -659,10 +722,61 @@ mod tests {
             request,
             "global.anthropic.claude-sonnet-4-6".to_string(),
             DEFAULT_MAX_TOKENS,
+            false,
         )
         .expect("request should map");
 
         assert!(matches!(mapped.thinking, Some(AnthropicThinking::Adaptive)));
+    }
+
+    #[test]
+    fn map_request_drops_non_default_sampling_for_restricted_models_when_compat_enabled() {
+        let mut request = basic_chat_request(Some(0.2), Some(0.7));
+        request.model = "claude-sonnet-5".to_string();
+
+        let mapped = map_request(
+            request,
+            "claude-sonnet-5".to_string(),
+            DEFAULT_MAX_TOKENS,
+            true,
+        )
+        .expect("request should map");
+
+        assert_eq!(mapped.temperature, None);
+        assert_eq!(mapped.top_p, None);
+    }
+
+    #[test]
+    fn map_request_keeps_non_default_sampling_for_non_restricted_models_when_compat_enabled() {
+        let request = basic_chat_request(Some(0.2), Some(0.7));
+
+        let mapped = map_request(
+            request,
+            "claude-sonnet-4-6".to_string(),
+            DEFAULT_MAX_TOKENS,
+            true,
+        )
+        .expect("request should map");
+
+        assert_eq!(mapped.temperature, Some(0.2));
+        assert_eq!(mapped.top_p, Some(0.7));
+    }
+
+    #[test]
+    fn map_request_sampling_compat_checks_request_model_only() {
+        let mut request = basic_chat_request(Some(0.2), Some(0.7));
+        request.model = "global.anthropic.claude-sonnet-5".to_string();
+
+        let mapped = map_request(
+            request,
+            "claude-sonnet-5".to_string(),
+            DEFAULT_MAX_TOKENS,
+            true,
+        )
+        .expect("request should map");
+
+        assert_eq!(mapped.temperature, Some(0.2));
+        assert_eq!(mapped.top_p, Some(0.7));
     }
 
     #[test]
@@ -783,8 +897,13 @@ mod tests {
             agent_context: None,
         };
 
-        let mapped = map_request(request, "claude-sonnet-5".to_string(), DEFAULT_MAX_TOKENS)
-            .expect("request should map");
+        let mapped = map_request(
+            request,
+            "claude-sonnet-5".to_string(),
+            DEFAULT_MAX_TOKENS,
+            false,
+        )
+        .expect("request should map");
 
         let AnthropicContentBlock::ToolUse { id: first_id, .. } = &mapped.messages[0].content[0]
         else {


### PR DESCRIPTION
## What
- add a sampling_compat switch to anthropic_messages::map_request
- when enabled, filter non-default temperature/top_p only for request models that reject custom sampling values
- switch model gating to exact matching on request.model (not substring matching and not upstream model)
- enable sampling_compat for anthropic messages provider complete/stream paths
- add tests for restricted-model filtering, non-restricted passthrough, and request-model-only gating

## Why
Some Anthropic models return 400 when non-default sampling parameters are sent. This keeps compatibility behavior explicit and scoped to the request model only.

## Validation
- cargo fmt
- cargo check
- cargo test anthropic_messages