### PR TITLE
feat(llm): add OrcaRouter as a named LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,33 @@ yomo serve
 
 You can also use the `--config` flag to specify a custom coniguration yaml file.
 
+#### Use OrcaRouter as the LLM provider
+
+Instead of Ollama, you can point YoMo at [OrcaRouter](https://www.orcarouter.ai) — an OpenAI-compatible gateway that routes to 180+ models (Anthropic, OpenAI, Google, DeepSeek and more) behind a single endpoint.
+
+Create a config file, e.g. `yomo.yaml`:
+
+```yaml
+providers:
+  - type: orcarouter
+    model_id: orca
+    params:
+      api_key: sk-orca-your-key
+      model: orcarouter/auto
+endpoints:
+  - path: /chat/completions
+    models: [orca]
+    default_model: orca
+```
+
+Then launch the server with your config:
+
+```sh
+yomo serve --config ./yomo.yaml
+```
+
+OrcaRouter's `orcarouter/auto` picks the best model for each request automatically. You can pin any of the gateway's models instead, e.g. `anthropic/claude-sonnet-4.6`, `openai/gpt-4o` or `deepseek/deepseek-chat`.
+
 ### Step 3. Implement the LLM Function Calling
 
 ```sh

--- a/src/llm_provider/mod.rs
+++ b/src/llm_provider/mod.rs
@@ -1,6 +1,7 @@
 pub mod anthropic_messages;
 pub mod openai;
 pub mod openai_compatible;
+pub mod orcarouter;
 pub mod provider;
 pub mod tokenhub;
 pub mod vertexai;

--- a/src/llm_provider/orcarouter.rs
+++ b/src/llm_provider/orcarouter.rs
@@ -1,0 +1,242 @@
+use async_stream::try_stream;
+use async_trait::async_trait;
+use axum::http::StatusCode;
+use futures_core::Stream;
+use futures_util::StreamExt;
+use std::collections::HashMap;
+use std::pin::Pin;
+
+use crate::llm_provider::openai_compatible::client::{ApiError, ClientError};
+use crate::llm_provider::openai_compatible::{client, mapper};
+use crate::llm_provider::{Provider, ProviderError, UnifiedEvent, UnifiedResponse};
+use crate::openai_http_mapping::validate_openai_request;
+use crate::openai_types::ChatCompletionRequest;
+use crate::serve_config::ConfigError;
+
+/// Default OrcaRouter endpoint.
+pub const ORCAROUTER_DEFAULT_BASE_URL: &str = "https://api.orcarouter.ai/v1";
+
+const CONTENT_FILTER_MESSAGE: &str =
+    "The request was rejected by the safety policy. Please revise your input and try again.";
+
+#[derive(Clone)]
+pub struct OrcaRouterProvider {
+    client: client::Client,
+    model_id: Option<String>,
+}
+
+impl OrcaRouterProvider {
+    pub fn new(client: client::Client, model_id: Option<String>) -> Self {
+        Self { client, model_id }
+    }
+}
+
+#[async_trait]
+impl<M> Provider<M> for OrcaRouterProvider {
+    fn model_id(&self) -> &str {
+        self.model_id.as_deref().unwrap_or("orcarouter")
+    }
+
+    async fn complete(
+        &self,
+        mut request: ChatCompletionRequest,
+        _metadata: &M,
+    ) -> Result<UnifiedResponse, ProviderError> {
+        if let Some(model_id) = &self.model_id {
+            request.model = model_id.clone();
+        }
+        validate_request(&request)?;
+        let model = request.model.clone();
+        let response = self
+            .client
+            .chat_completions(request)
+            .await
+            .map_err(|err| map_openai_error(err, &model))?;
+        mapper::map_response(response)
+    }
+
+    async fn stream<'a>(
+        &'a self,
+        mut request: ChatCompletionRequest,
+        _metadata: &M,
+    ) -> Result<
+        Pin<Box<dyn Stream<Item = Result<UnifiedEvent, ProviderError>> + Send + 'a>>,
+        ProviderError,
+    > {
+        if let Some(model_id) = &self.model_id {
+            request.model = model_id.clone();
+        }
+        validate_request(&request)?;
+        let model = request.model.clone();
+        let stream = self
+            .client
+            .chat_completions_stream(request)
+            .await
+            .map_err(|err| map_openai_error(err, &model))?;
+
+        let output = try_stream! {
+            futures_util::pin_mut!(stream);
+            let mut state = mapper::StreamMapState::default();
+
+            while let Some(item) = stream.next().await {
+                let chunk = item.map_err(|err| map_openai_error(err, &model))?;
+                for event in mapper::map_stream_chunk(chunk, &mut state) {
+                    yield event;
+                }
+            }
+        };
+
+        Ok(Box::pin(output))
+    }
+}
+
+pub fn build_orcarouter_provider(
+    params: &HashMap<String, String>,
+) -> Result<OrcaRouterProvider, ConfigError> {
+    let api_key = params.get("api_key").cloned().unwrap_or_default();
+    let mut config = client::Config::new(api_key);
+    let model_id = params.get("model").cloned();
+    let base_url = params
+        .get("base_url")
+        .cloned()
+        .unwrap_or_else(|| ORCAROUTER_DEFAULT_BASE_URL.to_string());
+    config = config.base_url(base_url);
+    let client =
+        client::Client::new(config).map_err(|err| ConfigError::InvalidProvider(err.to_string()))?;
+    Ok(OrcaRouterProvider::new(client, model_id))
+}
+
+fn validate_request(request: &ChatCompletionRequest) -> Result<(), ProviderError> {
+    validate_openai_request(request).map_err(ProviderError::internal)
+}
+
+fn map_openai_error(err: ClientError, model: &str) -> ProviderError {
+    match err {
+        ClientError::Api(ApiError::OpenAI { status, mut error }) if status.as_u16() == 400 => {
+            if error.code.as_deref() == Some("content_filter") {
+                error.message = CONTENT_FILTER_MESSAGE.to_string();
+            }
+            if error.code.as_deref() == Some("OperationNotSupported") {
+                error.message = format!(
+                    "The chatCompletion operation does not work with model {model}. Please choose different model and try again."
+                );
+                error.code = Some("operation_not_supported".to_string());
+            }
+            ProviderError::Public {
+                status: StatusCode::BAD_REQUEST,
+                error,
+            }
+        }
+        ClientError::Api(ApiError::OpenAI { status, error }) => {
+            ProviderError::internal_with_upstream_status(status, error.message)
+        }
+        ClientError::Api(ApiError::Unknown { status, body }) => {
+            ProviderError::internal_with_upstream_status(status, body)
+        }
+        other => ProviderError::internal(other.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::openai_types::ErrorDetail;
+
+    #[test]
+    fn build_provider_defaults_to_orcarouter_base_url() {
+        let provider = build_orcarouter_provider(&HashMap::new())
+            .expect("orcarouter provider should build without params");
+        assert_eq!(
+            <OrcaRouterProvider as Provider<()>>::model_id(&provider),
+            "orcarouter"
+        );
+    }
+
+    #[test]
+    fn build_provider_uses_configured_model_id() {
+        let params = HashMap::from([("model".to_string(), "openai/gpt-4o".to_string())]);
+        let provider = build_orcarouter_provider(&params)
+            .expect("orcarouter provider should build with a model");
+        assert_eq!(
+            <OrcaRouterProvider as Provider<()>>::model_id(&provider),
+            "openai/gpt-4o"
+        );
+    }
+
+    #[test]
+    fn build_provider_accepts_custom_base_url() {
+        let params =
+            HashMap::from([("base_url".to_string(), "https://example.com/v1".to_string())]);
+        let provider = build_orcarouter_provider(&params)
+            .expect("orcarouter provider should build with a custom base url");
+        assert_eq!(
+            <OrcaRouterProvider as Provider<()>>::model_id(&provider),
+            "orcarouter"
+        );
+    }
+
+    #[test]
+    fn map_openai_error_rewrites_content_filter_message() {
+        let err = ClientError::Api(ApiError::OpenAI {
+            status: reqwest::StatusCode::BAD_REQUEST,
+            error: ErrorDetail {
+                message: "upstream message".to_string(),
+                r#type: "invalid_request_error".to_string(),
+                code: Some("content_filter".to_string()),
+                param: None,
+            },
+        });
+
+        let mapped = map_openai_error(err, "orcarouter/auto");
+
+        let ProviderError::Public { status, error } = mapped else {
+            panic!("expected public error");
+        };
+        assert_eq!(status, axum::http::StatusCode::BAD_REQUEST);
+        assert_eq!(error.message, CONTENT_FILTER_MESSAGE);
+    }
+
+    #[test]
+    fn map_openai_error_rewrites_operation_not_supported() {
+        let err = ClientError::Api(ApiError::OpenAI {
+            status: reqwest::StatusCode::BAD_REQUEST,
+            error: ErrorDetail {
+                message: "original".to_string(),
+                r#type: "invalid_request_error".to_string(),
+                code: Some("OperationNotSupported".to_string()),
+                param: None,
+            },
+        });
+
+        let mapped = map_openai_error(err, "openai/gpt-5.5");
+
+        let ProviderError::Public { error, .. } = mapped else {
+            panic!("expected public error");
+        };
+        assert_eq!(error.code.as_deref(), Some("operation_not_supported"));
+        assert_eq!(
+            error.message,
+            "The chatCompletion operation does not work with model openai/gpt-5.5. Please choose different model and try again."
+        );
+    }
+
+    #[test]
+    fn map_openai_error_keeps_non_filter_bad_request_message() {
+        let err = ClientError::Api(ApiError::OpenAI {
+            status: reqwest::StatusCode::BAD_REQUEST,
+            error: ErrorDetail {
+                message: "original".to_string(),
+                r#type: "invalid_request_error".to_string(),
+                code: Some("invalid_parameter".to_string()),
+                param: None,
+            },
+        });
+
+        let mapped = map_openai_error(err, "orcarouter/auto");
+
+        let ProviderError::Public { error, .. } = mapped else {
+            panic!("expected public error");
+        };
+        assert_eq!(error.message, "original");
+    }
+}

--- a/src/model_api.rs
+++ b/src/model_api.rs
@@ -746,7 +746,7 @@ pub async fn build_model_api(
     };
 
     let app = axum::Router::new()
-        .route("/*path", axum::routing::post(handle_model_api::<(), ()>))
+        .route("/{*path}", axum::routing::post(handle_model_api::<(), ()>))
         .with_state(state);
     Ok(app)
 }

--- a/src/provider_registry.rs
+++ b/src/provider_registry.rs
@@ -10,6 +10,7 @@ use crate::llm_provider::anthropic_messages::{
 };
 use crate::llm_provider::openai::build_openai_provider;
 use crate::llm_provider::openai_compatible::build_openai_compatible_provider;
+use crate::llm_provider::orcarouter::build_orcarouter_provider;
 use crate::llm_provider::tokenhub::build_tokenhub_provider;
 use crate::llm_provider::vertexai::build_vertexai_provider;
 use crate::llm_provider::vllm_deepseek::build_vllm_deepseek_provider;
@@ -603,6 +604,7 @@ fn build_chat_provider_with_custom<M>(
         "openai-compatible" => Ok(Some(Arc::new(build_openai_compatible_provider(
             &provider.params,
         )?))),
+        "orcarouter" => Ok(Some(Arc::new(build_orcarouter_provider(&provider.params)?))),
         "openai" => Ok(Some(Arc::new(build_openai_provider(&provider.params)?))),
         "anthropic-messages" => Ok(Some(Arc::new(build_anthropic_messages_provider(
             &provider.params,
@@ -772,6 +774,34 @@ mod tests {
             .expect("default model should be selected");
 
         assert_eq!(selected.model_id, "chat-a");
+    }
+
+    #[test]
+    fn from_config_accepts_orcarouter_chat_provider() {
+        let providers = vec![ProviderConfig {
+            provider_type: "orcarouter".to_string(),
+            model_id: "orca".to_string(),
+            label: None,
+            params: HashMap::from([
+                ("api_key".to_string(), "sk-test".to_string()),
+                ("model".to_string(), "orcarouter/auto".to_string()),
+            ]),
+        }];
+        let endpoints = vec![EndpointConfig {
+            path: "/chat/completions".to_string(),
+            models: vec!["orca".to_string()],
+            default_model: Some("orca".to_string()),
+        }];
+        let strategy = Arc::new(ByEndpointModel::new(HashMap::from([(
+            EndpointKind::ChatCompletions,
+            endpoints[0].clone(),
+        )])));
+        let registry = ProviderRegistry::<()>::from_config(&providers, &endpoints, strategy)
+            .expect("orcarouter provider should be accepted for chat completions");
+        let selected = registry
+            .select_chat(EndpointKind::ChatCompletions, None, &())
+            .expect("chat provider should be selectable");
+        assert_eq!(selected.model_id, "orca");
     }
 
     #[test]


### PR DESCRIPTION
Adds [OrcaRouter](https://www.orcarouter.ai) as a model provider. OrcaRouter is an OpenAI-compatible model routing gateway that exposes 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax, xAI and others behind a single endpoint and API key. It also provides gateway-level security controls for AI agents.

I'm an engineer on the OrcaRouter team.

### What's in this PR
- New `orcarouter` provider type in `src/llm_provider/orcarouter.rs` — an OpenAI-compatible chat client that defaults to `https://api.orcarouter.ai/v1`. A `model` param selects the routed upstream (e.g. `orcarouter/auto`, or namespaced IDs like `anthropic/claude-sonnet-4.6`); `base_url` is overridable. Registered in `src/provider_registry.rs` (dispatch arm `"orcarouter" => ...`) and `src/llm_provider/mod.rs`.
- README: "Use OrcaRouter as the LLM provider" config example for `yomo serve --config`.
- 6 unit tests covering builder defaults/overrides and error mapping (`content_filter`, `OperationNotSupported`).

### Fix included: model API startup panic
`src/model_api.rs` registered the catch-all route with `/*path`, which axum 0.8 rejects at router construction (`Path segments must not start with '*'`). This made `yomo serve` panic on startup for *every* provider, so I changed the route to `/{*path}`. It's a one-line change required for the HTTP API to work at all.

### Verification
- `cargo fmt --check`: clean
- `cargo check`: clean
- `cargo test --lib`: 251 passed, 0 failed (includes the new orcarouter tests)
- Live test against a real OrcaRouter key via `yomo serve --config`:
  - `POST /v1/chat/completions` (non-stream) → `200`, content `PONG`; `orcarouter/auto` routed to `gemini-3.1-flash-lite`
  - `POST /v1/chat/completions` (`"stream": true`) → `200` with SSE chunks and `data: [DONE]`
